### PR TITLE
Make `CompoundTypeMetadata` match the returned object

### DIFF
--- a/src/hdf5_hl.d.ts
+++ b/src/hdf5_hl.d.ts
@@ -19,6 +19,7 @@ export declare type Dtype = string | {
 } | {
     array_type: ArrayTypeMetadata;
 };
+export type { Metadata };
 declare type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | BigInt64Array | BigUint64Array | Float32Array | Float64Array;
 export declare type GuessableDataTypes = TypedArray | number | number[] | string | string[];
 declare enum OBJECT_TYPE {

--- a/src/hdf5_hl.ts
+++ b/src/hdf5_hl.ts
@@ -77,6 +77,7 @@ function getAccessor(type: 0 | 1, size: Metadata["size"], signed: Metadata["sign
 
 export type OutputData = TypedArray | string | number | bigint | (string | number | bigint | OutputData)[];
 export type Dtype = string | {compound_type: CompoundTypeMetadata} | {array_type: ArrayTypeMetadata};
+export type { Metadata };
 
 function process_data(data: Uint8Array, metadata: Metadata): OutputData {
   // (for data coming out of Module)

--- a/src/hdf5_util_helpers.d.ts
+++ b/src/hdf5_util_helpers.d.ts
@@ -18,25 +18,26 @@ export interface H5T_class_t {
 }
 
 export interface Metadata {
-    signed: boolean,
-    cset: number,
-    compound_type?: CompoundTypeMetadata,
-    vlen: boolean,
-    littleEndian: boolean,
-    type: number,
-    size: number,
-    shape: Array<number>,
-    total_size: number,
     array_type?: ArrayTypeMetadata,
+    compound_type?: CompoundTypeMetadata,
+    cset: number,
+    littleEndian: boolean,
+    shape: Array<number>,
+    signed: boolean,
+    size: number,
+    total_size: number,
+    type: number,
+    vlen: boolean,
 }
 
 export interface CompoundMember extends Metadata {
+    name: string;
     offset: number;
 }
 
 export interface CompoundTypeMetadata {
-    name: string,
     members: Array<CompoundMember>
+    nmembers: number;
 }
 
 export interface ArrayTypeMetadata extends Metadata {

--- a/test/compound_and_array_test.mjs
+++ b/test/compound_and_array_test.mjs
@@ -1,51 +1,94 @@
 #!/usr/bin/env node
 
 import { strict as assert } from 'assert';
-import h5wasm from "../dist/node/hdf5_hl.js";
+import h5wasm from '../dist/node/hdf5_hl.js';
 
 async function compound_array_test() {
-
   await h5wasm.ready;
-  var f = new h5wasm.File("./test/array.h5", "r");
+  var f = new h5wasm.File('./test/array.h5', 'r');
 
   assert.deepEqual(
-    f.get("float_arr").value, 
-    new Float64Array([
-      0, 1, 2, 3,
-      4, 5, 6, 7
-    ])
+    f.get('float_arr').value,
+    new Float64Array([0, 1, 2, 3, 4, 5, 6, 7])
   );
 
-  assert.deepEqual(
-    f.get("string_arr").value, 
-    [
-      'hello', 'there',
-      'hello', 'there',
-      'hello', 'there',
-      'hello', 'there'
-    ]
-  );
+  assert.deepEqual(f.get('string_arr').value, [
+    'hello',
+    'there',
+    'hello',
+    'there',
+    'hello',
+    'there',
+    'hello',
+    'there',
+  ]);
 
-  assert.deepEqual(
-    f.get("compound").value,
-    [
-      [
-        new Float64Array([ 0, 1, 2, 3 ]),
-        [ 'hello', 'there', 'hello', 'there' ]
+  assert.deepEqual(f.get('compound').value, [
+    [new Float64Array([0, 1, 2, 3]), ['hello', 'there', 'hello', 'there']],
+    [new Float64Array([4, 5, 6, 7]), ['hello', 'there', 'hello', 'there']],
+  ]);
+
+  assert.deepEqual(f.get('compound').metadata, {
+    compound_type: {
+      members: [
+        {
+          array_type: {
+            cset: -1,
+            dims: [2, 2],
+            littleEndian: true,
+            signed: false,
+            size: 8,
+            type: 1,
+            vlen: false,
+          },
+          cset: -1,
+          littleEndian: true,
+          name: 'floaty',
+          offset: 0,
+          shape: [],
+          signed: false,
+          size: 32,
+          type: 10,
+          vlen: false,
+        },
+        {
+          array_type: {
+            cset: 0,
+            dims: [2, 2],
+            littleEndian: false,
+            signed: false,
+            size: 5,
+            type: 3,
+            vlen: false,
+          },
+          cset: -1,
+          littleEndian: false,
+          name: 'stringy',
+          offset: 32,
+          shape: [],
+          signed: false,
+          size: 20,
+          type: 10,
+          vlen: false,
+        },
       ],
-      [
-        new Float64Array([ 4, 5, 6, 7 ]),
-        [ 'hello', 'there', 'hello', 'there' ]
-      ]
-    ]
-    
-  )
+      nmembers: 2
+    },
+    cset: -1,
+    littleEndian: true,
+    shape: [2],
+    signed: false,
+    size: 52,
+    total_size: 2,
+    type: 6,
+    vlen: false,
+  });
 }
 
 export const tests = [
   {
-    description: "Read and process Array and Compound datatypes",
-    test: compound_array_test
-  }
-]
+    description: 'Read and process Array and Compound datatypes',
+    test: compound_array_test,
+  },
+];
 export default tests;


### PR DESCRIPTION
When trying to parse compound metadata, I noticed a few inconsistencies between the TS typing and the object itself.

Namely:
- `compound_type` has no field `name`. However, The field `name` is included in the members' metadata.
- `compound_type` has a field `nmembers`.

I changed the typings in consequence. I also added a test but this is more to document the format rather than catching typing errors because as I said in #19, I cannot test for TS issues in JS.