### PR TITLE
h5py-style boolean enums

### DIFF
--- a/src/hdf5_hl.d.ts
+++ b/src/hdf5_hl.d.ts
@@ -13,7 +13,7 @@ export declare const ACCESS_MODES: {
     readonly Sr: "H5F_ACC_SWMR_READ";
 };
 declare type ACCESS_MODESTRING = keyof typeof ACCESS_MODES;
-export declare type OutputData = TypedArray | string | number | bigint | (string | number | bigint | OutputData)[];
+export declare type OutputData = TypedArray | string | number | bigint | boolean | (string | number | bigint | boolean | OutputData)[];
 export declare type Dtype = string | {
     compound_type: CompoundTypeMetadata;
 } | {

--- a/src/hdf5_hl.ts
+++ b/src/hdf5_hl.ts
@@ -179,9 +179,9 @@ function isIterable(x: any): x is Iterable<unknown> {
 }
 
 function isH5PYBooleanEnum(enum_type: EnumTypeMetadata) {
-  return enum_type.members.length === 2 && 
-         enum_type.members[0] === "FALSE" &&
-         enum_type.members[1] === "TRUE";
+  return Object.keys(enum_type.members).length === 2 &&
+         enum_type.members["FALSE"] === 0 &&
+         enum_type.members["TRUE"] === 1;
 }
 
 function prepare_data(data: any, metadata: Metadata, shape?: Array<number> | null): {data: Uint8Array | string[], shape: number[]} {

--- a/test/bool_test.mjs
+++ b/test/bool_test.mjs
@@ -9,7 +9,7 @@ async function bool_test() {
 
   assert.deepEqual(
     f.get('bool').value,
-    new Int8Array([0, 1])
+    [ false, true ]
   );
 
   assert.deepEqual(f.get('bool').metadata, {


### PR DESCRIPTION
The convention in h5py is to store numpy arrays with dtype('bool') in an ENUM dataset in hdf5, with this definition:
```
      DATATYPE  H5T_ENUM {
         H5T_STD_I8LE;
         "FALSE"            0;
         "TRUE"             1;
      }
```

This PR would adopt that convention for reading (but not yet writing) boolean arrays back from HDF5 datasets and attributes that are stored in this way, by converting the Int8Array values to booleans during processing.