### PR TITLE
Check first if x is an object before checking if iterable

### DIFF
--- a/src/hdf5_hl.ts
+++ b/src/hdf5_hl.ts
@@ -199,7 +199,7 @@ function process_data(data: Uint8Array, metadata: Metadata, json_compatible: boo
 }
 
 function isIterable(x: any): x is Iterable<unknown> {
-  return Symbol.iterator in x;
+  return typeof x === 'object' && Symbol.iterator in x;
 }
 
 function isH5PYBooleanEnum(enum_type: EnumTypeMetadata) {


### PR DESCRIPTION
Fix `isIterable` failing for non-object values (such as numbers)

Encountered when trying to get `to_array` on a dataset containing a boolean scalar