### PR TITLE
Expose dataset compression filters information

### DIFF
--- a/src/hdf5_hl.d.ts
+++ b/src/hdf5_hl.d.ts
@@ -1,4 +1,4 @@
-import type { Status, Metadata, H5Module, CompoundTypeMetadata } from "./hdf5_util_helpers";
+import type { Status, Metadata, H5Module, CompoundTypeMetadata, Filter } from "./hdf5_util_helpers";
 export declare var Module: H5Module;
 export declare var FS: (FS.FileSystemType | null);
 declare const ready: Promise<H5Module>;
@@ -20,6 +20,7 @@ export declare type Dtype = string | {
     array_type: Metadata;
 };
 export type { Metadata };
+export type { Filter };
 declare type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | BigInt64Array | BigUint64Array | Float32Array | Float64Array;
 export declare type GuessableDataTypes = TypedArray | number | number[] | string | string[];
 declare enum OBJECT_TYPE {
@@ -99,6 +100,7 @@ export declare class Dataset extends HasAttrs {
     get metadata(): Metadata;
     get dtype(): Dtype;
     get shape(): number[];
+    get filters(): Filter[];
     get value(): OutputData;
     get json_value(): JSONCompatibleOutputData;
     slice(ranges: Array<Array<number>>): OutputData;

--- a/src/hdf5_hl.ts
+++ b/src/hdf5_hl.ts
@@ -1,4 +1,4 @@
-import type {Status, Metadata, H5Module, CompoundTypeMetadata, EnumTypeMetadata} from "./hdf5_util_helpers";
+import type {Status, Metadata, H5Module, CompoundTypeMetadata, EnumTypeMetadata, Filter} from "./hdf5_util_helpers";
 
 import ModuleFactory from './hdf5_util.js';
 
@@ -84,6 +84,7 @@ export type OutputData = TypedArray | string | number | bigint | boolean | Outpu
 export type JSONCompatibleOutputData = string | number | boolean | JSONCompatibleOutputData[];
 export type Dtype = string | {compound_type: CompoundTypeMetadata} | {array_type: Metadata};
 export type { Metadata };
+export type { Filter };
 
 function process_data(data: Uint8Array, metadata: Metadata, json_compatible: true): JSONCompatibleOutputData;
 function process_data(data: Uint8Array, metadata: Metadata, json_compatible: false): OutputData;
@@ -719,6 +720,10 @@ export class Dataset extends HasAttrs {
 
   get shape() {
     return this.metadata.shape;
+  }
+  
+  get filters(): Filter[] {
+    return Module.get_dataset_filters(this.file_id, this.path);
   }
 
   get value() {

--- a/src/hdf5_util.cc
+++ b/src/hdf5_util.cc
@@ -436,7 +436,7 @@ val get_dataset_filters(hid_t loc_id, const std::string& dataset_name_string)
     {
         unsigned int flags;
         char name[257];
-        size_t nelements;
+        size_t nelements = 16;
         unsigned int cd_values[16];
         H5Z_filter_t filter_id = H5Pget_filter2(plist_id, i, &flags, &nelements, cd_values, 256, name, NULL);
         

--- a/src/hdf5_util_helpers.d.ts
+++ b/src/hdf5_util_helpers.d.ts
@@ -66,11 +66,21 @@ export interface H5Module extends EmscriptenModule {
     H5F_ACC_CREAT: 16;
     H5F_ACC_SWMR_WRITE: 32;
     H5F_ACC_SWMR_READ: 64;
+    H5Z_FILTER_NONE: 0;
+    H5Z_FILTER_DEFLATE: 1;
+    H5Z_FILTER_SHUFFLE: 2;
+    H5Z_FILTER_FLETCHER32: 3;
+    H5Z_FILTER_SZIP: 4;
+    H5Z_FILTER_NBIT: 5;
+    H5Z_FILTER_SCALEOFFSET: 6;
+    H5Z_FILTER_RESERVED: 256;
+    H5Z_FILTER_MAX: 65535;
     create_group(file_id: bigint, name: string): number;
     create_vlen_str_dataset(file_id: bigint, dset_name: string, prepared_data: any, arg3: any, type: number, size: number, signed: boolean, vlen: boolean): number;
     get_dataset_data(file_id: bigint, path: string, arg2: bigint[] | null, arg3: bigint[] | null, arg4: bigint): number;
     refresh_dataset(file_id: bigint, path: string): number;
     get_dataset_metadata(file_id: bigint, path: string): Metadata;
+    get_dataset_filters(file_id: bigint, path: string): Filter[];
     flush(file_id: bigint): number;
     ccall: typeof ccall;
     get_names(file_id: bigint, path: string): string[];
@@ -86,4 +96,9 @@ export interface H5Module extends EmscriptenModule {
     FS: FS.FileSystemType,
     get_keys_vector(group_id: bigint, H5_index_t: number): Array<string>,
     get_attribute_metadata(loc_id: bigint, group_name_string: string, attribute_name_string: string): Metadata
+}
+
+export declare type Filter = {
+    id: number; 
+    name: string;
 }

--- a/test/filters_test.mjs
+++ b/test/filters_test.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { strict as assert } from "assert";
+import h5wasm from "../dist/node/hdf5_hl.js";
+
+async function filters_test() {
+  await h5wasm.ready;
+  const f = new h5wasm.File("./test/compressed.h5", "r");
+
+  assert.deepEqual(f.get("gzip").filters, [{ id: 1, name: "deflate" }]);
+
+  assert.deepEqual(f.get("gzip_shuffle").filters, [
+    { id: 2, name: "shuffle" },
+    { id: 1, name: "deflate" },
+  ]);
+
+  assert.deepEqual(f.get("scaleoffset").filters, [
+    { id: 6, name: "scaleoffset" },
+  ]);
+}
+
+export const tests = [
+  {
+    description: "Read dataset compression filters",
+    test: filters_test,
+  },
+];
+export default tests;

--- a/test/make_test_files.py
+++ b/test/make_test_files.py
@@ -1,24 +1,28 @@
 import h5py
 import numpy as np
 
-array_type = h5py.h5t.array_create(h5py.h5t.py_create("<f8"), (2,2))
-sarray_type = h5py.h5t.array_create(h5py.h5t.py_create("S5"), (2,2))
+with h5py.File("array.h5", "w") as f:
+    array_type = h5py.h5t.array_create(h5py.h5t.py_create("<f8"), (2,2))
+    sarray_type = h5py.h5t.array_create(h5py.h5t.py_create("S5"), (2,2))
 
-f = h5py.File("array.h5", "w")
+    f.create_dataset("float_arr", (2,), dtype=array_type)
+    f["float_arr"][:] = np.arange(8.0).reshape((2,2,2))
 
-f.create_dataset("float_arr", (2,), dtype=array_type)
-f["float_arr"][:] = np.arange(8.0).reshape((2,2,2))
+    f.create_dataset("string_arr", (2,), dtype=sarray_type)
+    f["string_arr"][:] = np.array([b"hello", b"there"] * 2 * 2).reshape((2,2,2))
 
-f.create_dataset("string_arr", (2,), dtype=sarray_type)
-f["string_arr"][:] = np.array([b"hello", b"there"] * 2 * 2).reshape((2,2,2))
+    f.create_dataset("compound", (2,), dtype=[("floaty", array_type), ("stringy",sarray_type)])
+    f["compound"][:] = np.array([(f["float_arr"][0], f["string_arr"][0]), (f["float_arr"][1], f["string_arr"][1])], dtype=f["compound"].dtype)
 
-f.create_dataset("compound", (2,), dtype=[("floaty", array_type), ("stringy",sarray_type)])
-f["compound"][:] = np.array([(f["float_arr"][0], f["string_arr"][0]), (f["float_arr"][1], f["string_arr"][1])], dtype=f["compound"].dtype)
+    f.create_dataset("bool", data=[[False, True], [True, False]], shape=(2,2))
+    f.create_dataset("bigint", data=np.arange(8).reshape(2,2,2), dtype="<i8", shape=(2,2,2))
+    f["datatype/value"] = np.dtype("S10")
 
-f.create_dataset("bool", data=[[False, True], [True, False]], shape=(2,2))
 
-f.create_dataset("bigint", data=np.arange(8).reshape(2,2,2), dtype="<i8", shape=(2,2,2))
-
-f["datatype/value"] = np.dtype("S10")
-
-f.close()
+with h5py.File("compressed.h5", "w") as f:
+    data = np.random.random((1000, 1000))
+    f.create_dataset("scaleoffset", data=data, scaleoffset=4)
+    f.create_dataset("gzip", data=data, compression="gzip")
+    f.create_dataset(
+        "gzip_shuffle", data=data, compression="gzip", shuffle=True
+    )

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -6,6 +6,7 @@ import compound_and_array_tests from "./compound_and_array_test.mjs";
 import datatype_test from "./datatype_test.mjs";
 import create_dataset from './create_group_dataset.mjs';
 import read_to_array from './to_array_test.mjs';
+import filters_test from './filters_test.mjs';
 
 let tests = [];
 const add_tests = (tests_in) => { /*global*/ tests = tests.concat(tests_in)}
@@ -15,6 +16,7 @@ add_tests(compound_and_array_tests);
 add_tests(create_dataset);
 add_tests(read_to_array);
 add_tests(datatype_test);
+add_tests(filters_test);
 
 async function run_test(test) {
     try {

--- a/test/to_array_test.mjs
+++ b/test/to_array_test.mjs
@@ -5,7 +5,7 @@ import h5wasm from '../dist/node/hdf5_hl.js';
 
 async function to_array_test() {
   await h5wasm.ready;
-  var f = new h5wasm.File('./test/array.h5', 'r');
+  const f = new h5wasm.File('./test/array.h5', 'r');
 
   assert.deepEqual(
     f.get('bigint').to_array(),


### PR DESCRIPTION
In H5Web, we have a feature that allows inspecting a dataset's filters when the information is available. To see it in action with our `h5grove` back-end provider:

1. https://h5web.panosc.eu/h5grove?file=compressed.h5
2. Select a dataset in the sidebar and switch to _Inspect_:

![image](https://user-images.githubusercontent.com/2936402/191699899-92585bc5-846e-4e92-b880-173334f5cea8.png)

![image](https://user-images.githubusercontent.com/2936402/191699794-d6ffa669-b5df-48b6-af3d-31377e5fa4c5.png)

**This PR aims to make this information available with the `h5wasm` provider as well.**

I had a bit of difficulty setting up the project, but after a bit of tinkering I did manage to get things to build. I also managed to test the built files locally in H5Web... and I'm happy to report that it works! :grin: 

That being said, I had never written C++/Emscripten code before, so please have a thorough look :sweat_smile: 