### PR TITLE
Support TS 5's `moduleResolution: "bundler"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/node/hdf5_hl.js",
   "module": "./dist/esm/hdf5_hl.js",
   "exports": {
+    "types": "./src/hdf5_hl.d.ts",
     "node": "./dist/node/hdf5_hl.js",
     "import": "./dist/esm/hdf5_hl.js"
   },

--- a/src/hdf5_hl.ts
+++ b/src/hdf5_hl.ts
@@ -1,4 +1,4 @@
-import type {Status, Metadata, H5Module, CompoundTypeMetadata, EnumTypeMetadata, Filter} from "./hdf5_util_helpers";
+import type {Status, Metadata, H5Module, CompoundMember, CompoundTypeMetadata, EnumTypeMetadata, Filter} from "./hdf5_util_helpers";
 
 import ModuleFactory from './hdf5_util.js';
 
@@ -83,8 +83,7 @@ function getAccessor(type: 0 | 1, size: Metadata["size"], signed: Metadata["sign
 export type OutputData = TypedArray | string | number | bigint | boolean | OutputData[];
 export type JSONCompatibleOutputData = string | number | boolean | JSONCompatibleOutputData[];
 export type Dtype = string | {compound_type: CompoundTypeMetadata} | {array_type: Metadata};
-export type { Metadata };
-export type { Filter };
+export type { Metadata, Filter, CompoundMember, CompoundTypeMetadata, EnumTypeMetadata };
 
 function process_data(data: Uint8Array, metadata: Metadata, json_compatible: true): JSONCompatibleOutputData;
 function process_data(data: Uint8Array, metadata: Metadata, json_compatible: false): OutputData;


### PR DESCRIPTION
With [this new module resolution option](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#moduleresolution-bundler), TypeScript looks at the [`exports` field](https://nodejs.org/api/packages.html#exports) of packages.

H5Wasm already defines an `exports` field but without a `types` entry for TypeScript. As a result, I think that TS looks at the `import` entry, which points to a JS file, and then tries to infer the types from that, which doesn't work as well as looking at the generated types and leads to `any` warnings with `strict: true`.

To be honest, this behaviour feels quite unintuitive to me, as I would have expected TS to fall back to reading the root `types` property in `package.json` ... but :shrug: 

While I'm at it, I'm also re-exporting a couple of helper types that we use in H5Web and were previously importing with a hacky path (which no longer works with `moduleResolution: "bundler"`... :sweat_smile:)