### PR TITLE
Add missing Emscripten type for `FS#mkdirTree`

### DIFF
--- a/src/emscripten.d.ts
+++ b/src/emscripten.d.ts
@@ -185,6 +185,7 @@ declare namespace FS {
         unmount(mountpoint: string): void,
 
         mkdir(path: string, mode?: number): any,
+        mkdirTree(path: string, mode?: number): void,
         mkdev(path: string, mode?: number, dev?: number): any,
         symlink(oldpath: string, newpath: string): any,
         rename(old_path: string, new_path: string): void,


### PR DESCRIPTION
I discovered this undocumented method of Emscripten's [File System API](https://emscripten.org/docs/api_reference/Filesystem-API.html) thanks to your work in `h5wasm-plugins`: https://github.com/h5wasm/h5wasm-plugins/blob/main/index.mjs#L19

The source in Emscripten's repo for reference: https://github.com/emscripten-core/emscripten/blob/1375c03ad476dba8f20c9c3919ef57f1af43e36b/src/library_fs.js#L669