### PR TITLE
Fix package exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,20 @@
   "name": "h5wasm",
   "version": "0.6.10",
   "description": "A high-level library for reading and writing HDF5 files from Javascript, using a wasm-compiled version of the HDF5 C library",
-  "types": "./src/hdf5_hl.d.ts",
   "type": "module",
-  "main": "./dist/node/hdf5_hl.js",
+  "main": "./dist/iife/hdf5_hl.js",
   "module": "./dist/esm/hdf5_hl.js",
+  "browser": "./dist/iife/h5wasm.js",
+  "types": "./src/hdf5_hl.d.ts",
   "exports": {
-    "types": "./src/hdf5_hl.d.ts",
-    "node": "./dist/node/hdf5_hl.js",
-    "import": "./dist/esm/hdf5_hl.js"
+    ".": {
+      "types": "./src/hdf5_hl.d.ts",
+      "import": "./dist/esm/hdf5_hl.js"
+    },
+    "./node": {
+      "types": "./src/hdf5_hl.d.ts",
+      "import": "./dist/node/hdf5_hl.js"
+    }
   },
   "scripts": {
     "build": "npm run build_esm && npm run build_node && npm run build_types && npm run build_iife",

--- a/test/bigendian_read.mjs
+++ b/test/bigendian_read.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { strict as assert } from 'assert';
-import h5wasm from 'h5wasm';
+import h5wasm from 'h5wasm/node';
 
 async function bigendian_read() {
   await h5wasm.ready;

--- a/test/bool_test.mjs
+++ b/test/bool_test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { strict as assert } from 'assert';
-import h5wasm from 'h5wasm';
+import h5wasm from 'h5wasm/node';
 
 async function bool_test() {
   await h5wasm.ready;

--- a/test/chunks_resize.mjs
+++ b/test/chunks_resize.mjs
@@ -3,7 +3,7 @@
 import { strict as assert } from 'assert';
 import { existsSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import h5wasm from "h5wasm";
+import h5wasm from "h5wasm/node";
 
 async function readwrite_chunked() {
 

--- a/test/compound_and_array_test.mjs
+++ b/test/compound_and_array_test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { strict as assert } from 'assert';
-import h5wasm from 'h5wasm';
+import h5wasm from 'h5wasm/node';
 
 async function compound_array_test() {
   await h5wasm.ready;

--- a/test/create_delete_attributes.mjs
+++ b/test/create_delete_attributes.mjs
@@ -3,7 +3,7 @@
 import { strict as assert } from 'assert';
 import { existsSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import h5wasm from "h5wasm";
+import h5wasm from "h5wasm/node";
 
 async function create_delete_string_attr() {
 

--- a/test/create_group_dataset.mjs
+++ b/test/create_group_dataset.mjs
@@ -3,7 +3,7 @@
 import { strict as assert } from 'assert';
 import { existsSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import h5wasm from "h5wasm";
+import h5wasm from "h5wasm/node";
 
 async function create_typedarray_datasets() {
 

--- a/test/create_read_compressed.mjs
+++ b/test/create_read_compressed.mjs
@@ -3,7 +3,7 @@
 import { strict as assert } from 'assert';
 import { existsSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import h5wasm from "h5wasm";
+import h5wasm from "h5wasm/node";
 
 async function readwrite_compressed() {
 

--- a/test/create_read_links.mjs
+++ b/test/create_read_links.mjs
@@ -3,7 +3,7 @@
 import { strict as assert } from 'assert';
 import { existsSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import h5wasm from "h5wasm";
+import h5wasm from "h5wasm/node";
 
 async function test_links() {
 

--- a/test/datatype_test.mjs
+++ b/test/datatype_test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { strict as assert } from 'assert';
-import h5wasm from 'h5wasm';
+import h5wasm from 'h5wasm/node';
 
 async function datatype_test() {
   await h5wasm.ready;

--- a/test/dimension_labels.mjs
+++ b/test/dimension_labels.mjs
@@ -3,7 +3,7 @@
 import { strict as assert } from 'assert';
 import { existsSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import h5wasm from "h5wasm";
+import h5wasm from "h5wasm/node";
 
 async function test_dimension_labels() {
 

--- a/test/dimension_scales.mjs
+++ b/test/dimension_scales.mjs
@@ -3,7 +3,7 @@
 import { strict as assert } from 'assert';
 import { existsSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import h5wasm from "h5wasm";
+import h5wasm from "h5wasm/node";
 
 async function test_dimension_scales() {
 

--- a/test/filters_test.mjs
+++ b/test/filters_test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { strict as assert } from "assert";
-import h5wasm from "h5wasm";
+import h5wasm from "h5wasm/node";
 
 async function filters_test() {
   await h5wasm.ready;

--- a/test/overwrite_dataset.mjs
+++ b/test/overwrite_dataset.mjs
@@ -3,7 +3,7 @@
 import { strict as assert } from 'assert';
 import { existsSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
-import h5wasm from "h5wasm";
+import h5wasm from "h5wasm/node";
 
 async function overwrite_datasets() {
 

--- a/test/to_array_test.mjs
+++ b/test/to_array_test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { strict as assert } from 'assert';
-import h5wasm from 'h5wasm';
+import h5wasm from 'h5wasm/node';
 
 async function to_array_test() {
   await h5wasm.ready;


### PR DESCRIPTION
Attempt at fixing an issue with importing h5wasm in NextJS: https://github.com/silx-kit/h5web/issues/1525.

I've used [arethetypeswrong](https://arethetypeswrong.github.io/) to diagnose the problem and [this guide](https://github.com/frehner/modern-guide-to-packaging-js-library#define-your-exports) to fix it.

![image](https://github.com/usnistgov/h5wasm/assets/2936402/e5e1c650-e1c8-4b88-ae0b-e9ef915edb19)

NextJS was using the ~CommonJS export~ ESM **Node** bundle instead of the ESM **browser** bundle. ~The problem is that `node` is not a valid `exports` entry; it should be `require` (along with `import` which is already present). Vite and webpack do not seem to mind, so I assume they skip the unknown `node` entry.  The recommendation is also for `require` to come after `import`, but I'm not sure this really matters in practice.~ see https://github.com/usnistgov/h5wasm/pull/64#issuecomment-1838842900

I'm not sure this PR will make `h5wasm` pass all the [arethetypeswrong](https://arethetypeswrong.github.io/) checks. I'm struggling to build `h5wasm` on my machine, so I can't upload a tarball to [arethetypeswrong](https://arethetypeswrong.github.io/) to check.