### PR TITLE
References support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test CI
 
 on:
   push:
-    branches: [ main, references ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       uses: mymindstorm/setup-emsdk@v12
       with:
         # Make sure to set a version number!
-        version: 3.1.28
+        version: 3.1.43
         # This is the name of the cache folder.
         # The cache folder will be placed in the build directory,
         #  so make sure it doesn't conflict with anything!
@@ -36,5 +36,10 @@ jobs:
         npm i
         npm run build
         
+    - name: check environment
+      run: |
+        pwd
+        ls -al ./test
+
     - name: test
       run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, references ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/src/hdf5_hl.d.ts
+++ b/src/hdf5_hl.d.ts
@@ -12,7 +12,7 @@ export declare const ACCESS_MODES: {
     readonly Sr: "H5F_ACC_SWMR_READ";
 };
 declare type ACCESS_MODESTRING = keyof typeof ACCESS_MODES;
-export declare type OutputData = TypedArray | string | number | bigint | boolean | OutputData[];
+export declare type OutputData = TypedArray | string | number | bigint | boolean | Reference | RegionReference | OutputData[];
 export declare type JSONCompatibleOutputData = string | number | boolean | JSONCompatibleOutputData[];
 export declare type Dtype = string | {
     compound_type: CompoundTypeMetadata;
@@ -29,13 +29,15 @@ declare type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Arra
  * `[i0, i1, s]` - select every `s` values in the range `i0` to `i1`
  **/
 declare type Slice = [] | [number | null] | [number | null, number | null] | [number | null, number | null, number | null];
-export declare type GuessableDataTypes = TypedArray | number | number[] | string | string[];
+export declare type GuessableDataTypes = TypedArray | number | number[] | string | string[] | Reference | Reference[] | RegionReference | RegionReference[];
 declare enum OBJECT_TYPE {
     DATASET = "Dataset",
     GROUP = "Group",
     BROKEN_SOFT_LINK = "BrokenSoftLink",
     EXTERNAL_LINK = "ExternalLink",
-    DATATYPE = "Datatype"
+    DATATYPE = "Datatype",
+    REFERENCE = "Reference",
+    REGION_REFERENCE = "RegionReference"
 }
 export declare class BrokenSoftLink {
     target: string;
@@ -51,6 +53,12 @@ export declare class ExternalLink {
 export declare class Datatype {
     type: OBJECT_TYPE;
     constructor();
+}
+export declare class Reference {
+    ref_data: Uint8Array;
+    constructor(ref_data: Uint8Array);
+}
+export declare class RegionReference extends Reference {
 }
 export declare class Attribute {
     file_id: bigint;
@@ -77,6 +85,7 @@ declare abstract class HasAttrs {
     get_attribute(name: string, json_compatible: false): OutputData;
     create_attribute(name: string, data: GuessableDataTypes, shape?: number[] | null, dtype?: string | null): void;
     delete_attribute(name: string): number;
+    create_reference(): Reference;
 }
 export declare class Group extends HasAttrs {
     constructor(file_id: bigint, path: string);
@@ -90,6 +99,7 @@ export declare class Group extends HasAttrs {
         obj_path: string;
     };
     get(obj_name: string): BrokenSoftLink | ExternalLink | Datatype | Group | Dataset | null;
+    dereference(ref: Reference | RegionReference): BrokenSoftLink | ExternalLink | Datatype | Group | Dataset | DatasetRegion | null;
     create_group(name: string): Group;
     create_dataset(args: {
         name: string;
@@ -126,6 +136,7 @@ export declare class Dataset extends HasAttrs {
     get json_value(): JSONCompatibleOutputData;
     slice(ranges: Slice[]): OutputData;
     write_slice(ranges: Slice[], data: any): void;
+    create_region_reference(ranges: Slice[]): RegionReference;
     to_array(): string | number | boolean | JSONCompatibleOutputData[];
     resize(new_shape: number[]): number;
     make_scale(scale_name?: string): void;
@@ -136,6 +147,13 @@ export declare class Dataset extends HasAttrs {
     set_dimension_label(index: number, label: string): void;
     get_dimension_labels(): (string | null)[];
     _value_getter(json_compatible?: boolean): OutputData;
+}
+export declare class DatasetRegion {
+    source_dataset: Dataset;
+    region_reference: RegionReference;
+    private _metadata?;
+    constructor(source_dataset: Dataset, region_reference: RegionReference);
+    get metadata(): Metadata;
 }
 export declare const h5wasm: {
     File: typeof File;

--- a/src/hdf5_hl.d.ts
+++ b/src/hdf5_hl.d.ts
@@ -154,6 +154,8 @@ export declare class DatasetRegion {
     private _metadata?;
     constructor(source_dataset: Dataset, region_reference: RegionReference);
     get metadata(): Metadata;
+    get value(): OutputData;
+    _value_getter(json_compatible?: boolean): OutputData;
 }
 export declare const h5wasm: {
     File: typeof File;

--- a/src/hdf5_hl.d.ts
+++ b/src/hdf5_hl.d.ts
@@ -162,6 +162,7 @@ export declare const h5wasm: {
     Group: typeof Group;
     Dataset: typeof Dataset;
     Datatype: typeof Datatype;
+    DatasetRegion: typeof DatasetRegion;
     ready: Promise<H5Module>;
     ACCESS_MODES: {
         readonly r: "H5F_ACC_RDONLY";

--- a/src/hdf5_hl.ts
+++ b/src/hdf5_hl.ts
@@ -1104,6 +1104,7 @@ export const h5wasm = {
   Group,
   Dataset,
   Datatype,
+  DatasetRegion,
   ready,
   ACCESS_MODES
 }

--- a/src/hdf5_util.cc
+++ b/src/hdf5_util.cc
@@ -706,6 +706,15 @@ herr_t setup_dataset(val dims_in, val maxdims_in, val chunks_in, int dtype, int 
             throw_error("data type not supported");
         }
     }
+    else if (dtype == H5T_REFERENCE)
+    {
+        if (dsize == sizeof(hobj_ref_t)) {
+            *filetype = H5Tcopy(H5T_STD_REF_OBJ);
+        }
+        else if (dsize == sizeof(hdset_reg_ref_t)) {
+            *filetype = H5Tcopy(H5T_STD_REF_DSETREG);
+        }
+    }
     else
     {
         throw_error("data type not supported");
@@ -1104,7 +1113,7 @@ val get_region_metadata(hid_t loc_id, const val ref_data_in)
     hid_t dtype;
     hid_t dcpl;
     herr_t status;
-    std::vector<uint8_t> ref_data_vec = convertJSArrayToNumberVector<uint8_t>(ref_data_in);
+    const std::vector<uint8_t> ref_data_vec = convertJSArrayToNumberVector<uint8_t>(ref_data_in);
     const hobj_ref_t *ref_ptr = (hobj_ref_t *)ref_data_vec.data();
     hid_t ds_id = H5Rdereference2(loc_id, H5P_DEFAULT, H5R_DATASET_REGION, ref_ptr);
 

--- a/src/hdf5_util.cc
+++ b/src/hdf5_util.cc
@@ -340,15 +340,15 @@ val get_abstractDS_metadata(hid_t dspace, hid_t dtype, hid_t dcpl)
 
     int rank = H5Sget_simple_extent_ndims(dspace);
     int total_size = H5Sget_simple_extent_npoints(dspace);
-    hsize_t dims_out[rank];
-    hsize_t maxdims_out[rank];
-    int ndims = H5Sget_simple_extent_dims(dspace, dims_out, maxdims_out);
+    std::vector<hsize_t> dims_out(rank);
+    std::vector<hsize_t> maxdims_out(rank);
+    int ndims = H5Sget_simple_extent_dims(dspace, dims_out.data(), maxdims_out.data());
     val shape = val::array();
     val maxshape = val::array();
     for (int d = 0; d < ndims; d++)
     {
-        shape.set(d, (uint)dims_out[d]);
-        maxshape.set(d, (uint)maxdims_out[d]);
+        shape.set(d, (uint)dims_out.at(d));
+        maxshape.set(d, (uint)maxdims_out.at(d));
     }
 
     attr.set("shape", shape);
@@ -358,12 +358,12 @@ val get_abstractDS_metadata(hid_t dspace, hid_t dtype, hid_t dcpl)
     if (dcpl) {
         H5D_layout_t layout = H5Pget_layout(dcpl);
         if (layout == H5D_CHUNKED) {
-            hsize_t chunk_dims_out[ndims];
-            H5Pget_chunk(dcpl, ndims, chunk_dims_out);
+            std::vector<hsize_t> chunk_dims_out(ndims);
+            H5Pget_chunk(dcpl, ndims, chunk_dims_out.data());
             val chunks = val::array();
             for (int c = 0; c < ndims; c++)
             {
-                chunks.set(c, (uint)chunk_dims_out[c]);
+                chunks.set(c, (uint)chunk_dims_out.at(c));
             }
             attr.set("chunks", chunks);
         }

--- a/src/hdf5_util.cc
+++ b/src/hdf5_util.cc
@@ -325,6 +325,11 @@ val get_dtype_metadata(hid_t dtype)
         enum_type.set("members", members);
         attr.set("enum_type", enum_type);
     }
+    else if (dtype_class == H5T_REFERENCE)
+    {
+        std::string ref_type = (H5Tequal(dtype, H5T_STD_REF_OBJ)) ? "object" : "region";
+        attr.set("ref_type", ref_type);
+    }
 
     bool littleEndian = (order == H5T_ORDER_LE);
     attr.set("vlen", (bool)H5Tis_variable_str(dtype));
@@ -523,9 +528,9 @@ int read_write_dataset_data(hid_t loc_id, const std::string& dataset_name_string
 
     if (count_out != val::null() && offset_out != val::null())
     {
-        std::vector<hsize_t> count = vecFromJSArray<hsize_t>(count_out);
-        std::vector<hsize_t> offset = vecFromJSArray<hsize_t>(offset_out);
-        std::vector<hsize_t> strides = vecFromJSArray<hsize_t>(stride_out);
+        std::vector<hsize_t> count = convertJSArrayToNumberVector<hsize_t>(count_out);
+        std::vector<hsize_t> offset = convertJSArrayToNumberVector<hsize_t>(offset_out);
+        std::vector<hsize_t> strides = convertJSArrayToNumberVector<hsize_t>(stride_out);
 
         memspace = H5Screate_simple(count.size(), &count[0], nullptr);
         status = H5Sselect_hyperslab(dspace, H5S_SELECT_SET, &offset[0], &strides[0], &count[0], NULL);
@@ -1036,6 +1041,106 @@ val get_dimension_labels(hid_t loc_id, const std::string& target_dset_name_strin
     return dim_labels;
 }
 
+// References
+val create_object_reference(hid_t loc_id, const std::string& obj_name_string)
+{
+    const char *obj_name = obj_name_string.c_str();
+    std::vector<uint8_t> ref(sizeof(hobj_ref_t));
+    herr_t status = H5Rcreate(ref.data(), loc_id, obj_name, H5R_OBJECT, (hid_t)-1);
+    return val::array(ref);
+}
+
+val create_region_reference(hid_t loc_id, const std::string& dataset_name_string, val count_out, val offset_out, val stride_out)
+{
+    hid_t ds_id;
+    hid_t dspace;
+    std::vector<uint8_t> ref(sizeof(hdset_reg_ref_t));
+    herr_t status;
+    const char *dataset_name = dataset_name_string.c_str();
+
+    ds_id = H5Dopen2(loc_id, dataset_name, H5P_DEFAULT);
+    dspace = H5Dget_space(ds_id);
+    if (count_out != val::null() && offset_out != val::null())
+    {
+        std::vector<hsize_t> count = convertJSArrayToNumberVector<hsize_t>(count_out);
+        std::vector<hsize_t> offset = convertJSArrayToNumberVector<hsize_t>(offset_out);
+        std::vector<hsize_t> strides = convertJSArrayToNumberVector<hsize_t>(stride_out);
+        status = H5Sselect_hyperslab(dspace, H5S_SELECT_SET, &offset[0], &strides[0], &count[0], NULL);
+    }
+    else
+    {
+        status = H5Sselect_all(dspace);
+    }
+    status = H5Rcreate(ref.data(), loc_id, dataset_name, H5R_DATASET_REGION, dspace);
+    H5Sclose(dspace);
+    H5Dclose(ds_id);
+    return val::array(ref);
+}
+
+val get_referenced_name(hid_t loc_id, const val ref_data_in, const bool is_object)
+{
+    ssize_t namesize = 0;
+    std::vector<uint8_t> ref_data_vec = convertJSArrayToNumberVector<uint8_t>(ref_data_in);
+    const hobj_ref_t *ref_ptr = (hobj_ref_t *)ref_data_vec.data();
+    val output = val::null();
+    const H5R_type_t ref_type = (is_object) ? H5R_OBJECT : H5R_DATASET_REGION;
+    hid_t object_id = H5Rdereference2(loc_id, H5P_DEFAULT, ref_type, ref_ptr);
+    namesize = H5Iget_name(object_id, nullptr, 0);
+    if (namesize > 0)
+    {
+        char *name = new char[namesize + 1];
+        H5Iget_name(object_id, name, namesize + 1);
+
+        output = val::u8string(name);
+        delete[] name;
+    }
+    H5Oclose(object_id);
+    return output;
+}
+
+val get_region_metadata(hid_t loc_id, const val ref_data_in)
+{
+    hid_t dspace;
+    hid_t dtype;
+    hid_t dcpl;
+    herr_t status;
+    std::vector<uint8_t> ref_data_vec = convertJSArrayToNumberVector<uint8_t>(ref_data_in);
+    const hobj_ref_t *ref_ptr = (hobj_ref_t *)ref_data_vec.data();
+    hid_t ds_id = H5Rdereference2(loc_id, H5P_DEFAULT, H5R_DATASET_REGION, ref_ptr);
+
+    dtype = H5Dget_type(ds_id);
+    dspace = H5Rget_region(ds_id, H5R_DATASET_REGION, ref_ptr);
+    dcpl = H5Dget_create_plist(ds_id);
+    // fill in shape, maxshape, chunks, total_size
+    val metadata = get_abstractDS_metadata(dspace, dtype, dcpl);
+    // then override the ones that are specific to a region:
+    int total_size = H5Sget_select_npoints(dspace);
+    metadata.set("total_size", total_size);
+
+    int rank = H5Sget_simple_extent_ndims(dspace);
+    // shape will be null if the selection is not a regular hyperslab
+    val shape = val::null();
+    htri_t is_regular = H5Sis_regular_hyperslab(dspace);
+    if (is_regular > 0)
+    {
+        std::vector<hsize_t> count(rank);
+        std::vector<hsize_t> block(rank);
+        htri_t success = H5Sget_regular_hyperslab(dspace, nullptr, nullptr, count.data(), block.data());
+        shape = val::array();
+        for (int d = 0; d < rank; d++)
+        {
+            int blocksize = (block.at(d) == NULL) ? 1 : block.at(d); 
+            shape.set(d, (uint)(count.at(d) * blocksize));
+        }
+    }
+    metadata.set("shape", shape);
+    H5Dclose(ds_id);
+    H5Sclose(dspace);
+    H5Tclose(dtype);
+    H5Pclose(dcpl);
+    return metadata;
+}
+
 EMSCRIPTEN_BINDINGS(hdf5)
 {
     function("get_keys", &get_keys_vector);
@@ -1074,6 +1179,10 @@ EMSCRIPTEN_BINDINGS(hdf5)
     function("get_attached_scales", &get_attached_scales);
     function("get_dimension_labels", &get_dimension_labels);
     function("set_dimension_label", &set_dimension_label);
+    function("create_object_reference", &create_object_reference);
+    function("create_region_reference", &create_region_reference);
+    function("get_referenced_name", &get_referenced_name);
+    function("get_region_metadata", &get_region_metadata);
 
     class_<H5L_info2_t>("H5L_info2_t")
         .constructor<>()
@@ -1124,6 +1233,8 @@ EMSCRIPTEN_BINDINGS(hdf5)
     constant("H5O_TYPE_GROUP", (int)H5O_TYPE_GROUP);
     constant("H5O_TYPE_DATASET", (int)H5O_TYPE_DATASET);
     constant("H5O_TYPE_NAMED_DATATYPE", (int)H5O_TYPE_NAMED_DATATYPE);
+    constant("SIZEOF_OBJ_REF", (int)(sizeof(hobj_ref_t)));
+    constant("SIZEOF_DSET_REGION_REF", (int)(sizeof(hdset_reg_ref_t)));
 
     constant("H5Z_FILTER_NONE", H5Z_FILTER_NONE);
     constant("H5Z_FILTER_DEFLATE", H5Z_FILTER_DEFLATE);

--- a/src/hdf5_util_helpers.d.ts
+++ b/src/hdf5_util_helpers.d.ts
@@ -25,6 +25,7 @@ export interface Metadata {
     enum_type?: EnumTypeMetadata,
     littleEndian: boolean,
     maxshape: Array<number> | null,
+    ref_type?: 'object' | 'region',
     shape: Array<number>,
     signed: boolean,
     size: number,
@@ -59,6 +60,8 @@ export interface H5Module extends EmscriptenModule {
     get_external_link(file_id: bigint, obj_path: string): {filename: string, obj_path: string};
     H5O_TYPE_DATASET: number;
     H5O_TYPE_GROUP: number;
+    SIZEOF_OBJ_REF: number;
+    SIZEOF_DSET_REGION_REF: number;
     H5G_GROUP: number;
     H5G_DATASET: number;
     H5G_TYPE: number;
@@ -114,6 +117,10 @@ export interface H5Module extends EmscriptenModule {
     get_attached_scales(loc_id: bigint, target_dset_name: string, index: number): string[],
     set_dimension_label(loc_id: bigint, target_dset_name: string, index: number, label: string): number,
     get_dimension_labels(loc_id: bigint, target_dset_name: string): Array<string | null>,
+    create_object_reference(loc_id: bigint, target_name: string): Uint8Array,
+    create_region_reference(file_id: bigint, path: string, count: bigint[] | null, offset: bigint[] | null, strides: bigint[] | null): Uint8Array,
+    get_referenced_name(loc_id: bigint, ref_ptr: Uint8Array, is_object: boolean): string;
+    get_region_metadata(loc_id: bigint, ref_ptr: Uint8Array): Metadata;
 }
 
 export declare type Filter = {

--- a/src/hdf5_util_helpers.d.ts
+++ b/src/hdf5_util_helpers.d.ts
@@ -121,6 +121,7 @@ export interface H5Module extends EmscriptenModule {
     create_region_reference(file_id: bigint, path: string, count: bigint[] | null, offset: bigint[] | null, strides: bigint[] | null): Uint8Array,
     get_referenced_name(loc_id: bigint, ref_ptr: Uint8Array, is_object: boolean): string;
     get_region_metadata(loc_id: bigint, ref_ptr: Uint8Array): Metadata;
+    get_region_data(loc_id: bigint, ref_data: Uint8Array, rdata_ptr: bigint): number;
 }
 
 export declare type Filter = {

--- a/test/create_read_references.mjs
+++ b/test/create_read_references.mjs
@@ -17,8 +17,6 @@ async function test_refs() {
   const DATASET_NAME = "data";
   const REFS_GROUP = "refs";
   const OBJECT_REF_DATASET_NAME = "object_refs";
-  const OBJECT_TARGET_GROUP = "test_group";
-  const OBJECT_TARGET_DSET = "data";
   const REGION_REF_DATASET_NAME = "dset_region_refs";
   const REGION_REF_DATA_0 = [[11.], [ 8.], [ 5.]];
   const REGION_REF_DATA_1 = [[12., 11., 10.]];

--- a/test/create_read_references.mjs
+++ b/test/create_read_references.mjs
@@ -73,6 +73,11 @@ async function test_refs() {
     assert.strictEqual(obj_1.path, `/${DATASET_GROUP}/${DATASET_NAME}`);
     
     const region_refs = refs_group.get(REGION_REF_DATASET_NAME).value;
+    const [region_0, region_1] = region_refs.map((ref) => read_file.dereference(ref));
+    assert(region_0 instanceof h5wasm.DatasetRegion);
+    assert.deepEqual(region_0.value, new Float32Array(REGION_REF_DATA_0.flat()));
+    assert(region_1 instanceof h5wasm.DatasetRegion);
+    assert.deepEqual(region_1.value, new Float32Array(REGION_REF_DATA_1.flat()));
     // assert.deepEqual(hard_link_dataset.value, DATA);
 
     read_file.close()

--- a/test/create_read_references.mjs
+++ b/test/create_read_references.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import { strict as assert } from 'assert';
+import { existsSync, mkdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import h5wasm from "h5wasm";
+
+async function test_refs() {
+
+  await h5wasm.ready;
+  const PATH = join(".", "test", "tmp");
+  const FILEPATH = join(PATH, "refs.h5");
+  const VALUES = [12,11,10,9,8,7,6,5,4,3,2,1];
+  const DATA = new Float32Array(VALUES);
+  const SHAPE = [4,3];
+  const DATASET_GROUP = "entry";
+  const DATASET_NAME = "data";
+  const REFS_GROUP = "refs";
+  const OBJECT_REF_DATASET_NAME = "object_refs";
+  const OBJECT_TARGET_GROUP = "test_group";
+  const OBJECT_TARGET_DSET = "data";
+  const REGION_REF_DATASET_NAME = "dset_region_refs";
+  const REGION_REF_DATA_0 = [[11.], [ 8.], [ 5.]];
+  const REGION_REF_DATA_1 = [[12., 11., 10.]];
+
+  if (!(existsSync(PATH))) {
+    mkdirSync(PATH);
+  }
+  
+  // write
+  { 
+    const write_file = new h5wasm.File(FILEPATH, "w");
+
+    write_file.create_group(DATASET_GROUP);
+    const dataset_group = write_file.get(DATASET_GROUP);
+    dataset_group.create_dataset({name: DATASET_NAME, data: DATA, shape: SHAPE});
+    
+    const object_refs = [
+      dataset_group.create_reference(),
+      dataset_group.get(DATASET_NAME).create_reference(),
+    ];
+
+    write_file.create_group(REFS_GROUP);
+    const refs_group = write_file.get(REFS_GROUP);
+    refs_group.create_dataset({name: OBJECT_REF_DATASET_NAME, data: object_refs});
+
+    const dataset = dataset_group.get(DATASET_NAME);
+    const region_refs = [
+      dataset.create_region_reference([[0,3], [1,2]]),
+      dataset.create_region_reference([[0,1], []]),
+    ]
+    refs_group.create_dataset({name: REGION_REF_DATASET_NAME, data: region_refs})
+
+    write_file.flush();
+    write_file.close();
+  }
+
+  // read
+  {
+    const read_file = new h5wasm.File(FILEPATH, "r");
+
+    const dataset_group = read_file.get(DATASET_GROUP);
+    assert(dataset_group instanceof h5wasm.Group);
+
+    const refs_group = read_file.get(REFS_GROUP);
+    assert(refs_group instanceof h5wasm.Group);
+
+    const object_refs = refs_group.get(OBJECT_REF_DATASET_NAME).value;
+    const [obj_0, obj_1] = object_refs.map((ref) => read_file.dereference(ref));
+    assert(obj_0 instanceof h5wasm.Group);
+    assert.strictEqual(obj_0.path, `/${DATASET_GROUP}`);
+    assert(obj_1 instanceof h5wasm.Dataset);
+    assert.strictEqual(obj_1.path, `/${DATASET_GROUP}/${DATASET_NAME}`);
+    
+    const region_refs = refs_group.get(REGION_REF_DATASET_NAME).value;
+    // assert.deepEqual(hard_link_dataset.value, DATA);
+
+    read_file.close()
+  }
+
+  // cleanup file when finished:
+  unlinkSync(FILEPATH);
+
+}
+
+export const tests = [
+  {
+    description: "Create and read object and region references",
+    test: test_refs
+  },
+];
+
+export default tests;

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -15,6 +15,7 @@ import bigendian_read from './bigendian_read.mjs';
 import create_compressed from './create_read_compressed.mjs';
 import dimension_labels from './dimension_labels.mjs';
 import dimension_scales from './dimension_scales.mjs';
+import references from './create_read_references.mjs';
 
 let tests = [];
 const add_tests = (tests_in) => { /*global*/ tests = tests.concat(tests_in)}
@@ -33,6 +34,7 @@ add_tests(bigendian_read);
 add_tests(create_compressed);
 add_tests(dimension_labels);
 add_tests(dimension_scales);
+add_tests(references);
 
 async function run_test(test) {
     try {

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -36,6 +36,7 @@ add_tests(dimension_labels);
 add_tests(dimension_scales);
 add_tests(references);
 
+let passed = true;
 async function run_test(test) {
     try {
         await test.test();
@@ -44,6 +45,7 @@ async function run_test(test) {
     catch (error) {
         console.log('x', test.description);
         console.log(error.stack);
+        passed = false;
     }
 }
 
@@ -54,3 +56,6 @@ async function run_tests(tests) {
 }
 
 await run_tests(tests);
+if (!passed) {
+    throw new Error("Tests did not complete successfuly");
+}


### PR DESCRIPTION
Adding support for 

- Creating object references (to a Dataset or Group)
- Creating region references to a dataset (similar to a slice)
- Writing object or region references to a Dataset (there are a special dtypes for references)
- Reading object or region references from a Dataset in an HDF5 file (they become instances of `Reference` or `RegionReference`)
- Dereferencing a reference, which returns the Group or Dataset it points to
- Retrieving the data from the region defined in a `RegionReference` (the reference contains information identifying the dataset it refers to, but must be dereferenced from the same File object as the source Dataset)

## Examples:
### Creating references, and writing references to datasets:
```javascript
const VALUES = [12,11,10,9,8,7,6,5,4,3,2,1];
const DATA = new Float32Array(VALUES);
const SHAPE = [4,3];
const DATASET_GROUP = "entry";
const DATASET_NAME = "data";
const REFS_GROUP = "refs";
const OBJECT_REF_DATASET_NAME = "object_refs";
const REGION_REF_DATASET_NAME = "dset_region_refs";
const REGION_REF_DATA_0 = [[11.], [ 8.], [ 5.]];
const REGION_REF_DATA_1 = [[12., 11., 10.]];
const write_file = new h5wasm.File(FILEPATH, "w");

write_file.create_group(DATASET_GROUP);
const dataset_group = write_file.get(DATASET_GROUP);
dataset_group.create_dataset({name: DATASET_NAME, data: DATA, shape: SHAPE});

const object_refs = [
  dataset_group.create_reference(),
  dataset_group.get(DATASET_NAME).create_reference(),
];

write_file.create_group(REFS_GROUP);
const refs_group = write_file.get(REFS_GROUP);
refs_group.create_dataset({name: OBJECT_REF_DATASET_NAME, data: object_refs});

const dataset = dataset_group.get(DATASET_NAME);
const region_refs = [
  dataset.create_region_reference([[0,3], [1,2]]),
  dataset.create_region_reference([[0,1], []]),
]
refs_group.create_dataset({name: REGION_REF_DATASET_NAME, data: region_refs});
```

### Reading references from a dataset, and dereferencing them:
```javascript
const read_file = new h5wasm.File(FILEPATH, "r");

const dataset_group = read_file.get(DATASET_GROUP);
assert(dataset_group instanceof h5wasm.Group);

const refs_group = read_file.get(REFS_GROUP);
assert(refs_group instanceof h5wasm.Group);

const object_refs = refs_group.get(OBJECT_REF_DATASET_NAME).value;
const [obj_0, obj_1] = object_refs.map((ref) => read_file.dereference(ref));
assert(obj_0 instanceof h5wasm.Group);
assert.strictEqual(obj_0.path, `/${DATASET_GROUP}`);
assert(obj_1 instanceof h5wasm.Dataset);
assert.strictEqual(obj_1.path, `/${DATASET_GROUP}/${DATASET_NAME}`);

const region_refs = refs_group.get(REGION_REF_DATASET_NAME).value;
const [region_0, region_1] = region_refs.map((ref) => read_file.dereference(ref));
assert(region_0 instanceof h5wasm.DatasetRegion);
assert.deepEqual(region_0.value, new Float32Array(REGION_REF_DATA_0.flat()));
assert(region_1 instanceof h5wasm.DatasetRegion);
assert.deepEqual(region_1.value, new Float32Array(REGION_REF_DATA_1.flat()));
// assert.deepEqual(hard_link_dataset.value, DATA);
```