### PR TITLE
Support reading empty datasets and attributes

### DIFF
--- a/src/hdf5_hl.d.ts
+++ b/src/hdf5_hl.d.ts
@@ -66,13 +66,13 @@ export declare class Attribute {
     name: string;
     metadata: Metadata;
     dtype: Dtype;
-    shape: number[];
+    shape: number[] | null;
     private _value?;
     private _json_value?;
     constructor(file_id: bigint, path: string, name: string);
-    get value(): OutputData;
-    get json_value(): JSONCompatibleOutputData;
-    to_array(): string | number | boolean | JSONCompatibleOutputData[];
+    get value(): OutputData | null;
+    get json_value(): JSONCompatibleOutputData | null;
+    to_array(): JSONCompatibleOutputData | null;
 }
 declare abstract class HasAttrs {
     file_id: bigint;
@@ -132,14 +132,14 @@ export declare class Dataset extends HasAttrs {
     refresh(): void;
     get metadata(): Metadata;
     get dtype(): Dtype;
-    get shape(): number[];
+    get shape(): number[] | null;
     get filters(): Filter[];
-    get value(): OutputData;
-    get json_value(): JSONCompatibleOutputData;
-    slice(ranges: Slice[]): OutputData;
+    get value(): OutputData | null;
+    get json_value(): JSONCompatibleOutputData | null;
+    slice(ranges: Slice[]): OutputData | null;
     write_slice(ranges: Slice[], data: any): void;
     create_region_reference(ranges: Slice[]): RegionReference;
-    to_array(): string | number | boolean | JSONCompatibleOutputData[];
+    to_array(): JSONCompatibleOutputData | null;
     resize(new_shape: number[]): number;
     make_scale(scale_name?: string): void;
     attach_scale(index: number, scale_dset_path: string): void;
@@ -148,7 +148,9 @@ export declare class Dataset extends HasAttrs {
     get_scale_name(): string | null;
     set_dimension_label(index: number, label: string): void;
     get_dimension_labels(): (string | null)[];
-    _value_getter(json_compatible?: boolean): OutputData;
+    _value_getter(json_compatible?: false): OutputData | null;
+    _value_getter(json_compatible: true): JSONCompatibleOutputData | null;
+    _value_getter(json_compatible: boolean): OutputData | JSONCompatibleOutputData | null;
 }
 export declare class DatasetRegion {
     source_dataset: Dataset;
@@ -156,8 +158,10 @@ export declare class DatasetRegion {
     private _metadata?;
     constructor(source_dataset: Dataset, region_reference: RegionReference);
     get metadata(): Metadata;
-    get value(): OutputData;
-    _value_getter(json_compatible?: boolean): OutputData;
+    get value(): OutputData | null;
+    _value_getter(json_compatible?: false): OutputData | null;
+    _value_getter(json_compatible: true): JSONCompatibleOutputData | null;
+    _value_getter(json_compatible: boolean): OutputData | JSONCompatibleOutputData | null;
 }
 export declare const h5wasm: {
     File: typeof File;

--- a/src/hdf5_util.cc
+++ b/src/hdf5_util.cc
@@ -345,15 +345,26 @@ val get_abstractDS_metadata(hid_t dspace, hid_t dtype, hid_t dcpl)
 {
     val attr = get_dtype_metadata(dtype);
 
-    int rank = H5Sget_simple_extent_ndims(dspace);
+    int type = H5Sget_simple_extent_type(dspace);
     int total_size = H5Sget_simple_extent_npoints(dspace);
+    attr.set("total_size", total_size);
+
+    if (type == H5S_NULL) {
+        attr.set("shape", val::null());
+        attr.set("maxshape", val::null());
+        attr.set("chunks", val::null());
+        return attr;
+    }
+
+    int rank = H5Sget_simple_extent_ndims(dspace);
     std::vector<hsize_t> dims_out(rank);
     std::vector<hsize_t> maxdims_out(rank);
+
     int ndims = H5Sget_simple_extent_dims(dspace, dims_out.data(), maxdims_out.data());
+
     val shape = val::array();
     val maxshape = val::array();
-    for (int d = 0; d < ndims; d++)
-    {
+    for (int d = 0; d < ndims; d++) {
         shape.set(d, (uint)dims_out.at(d));
         maxshape.set(d, (uint)maxdims_out.at(d));
     }
@@ -364,19 +375,20 @@ val get_abstractDS_metadata(hid_t dspace, hid_t dtype, hid_t dcpl)
 
     if (dcpl) {
         H5D_layout_t layout = H5Pget_layout(dcpl);
+
         if (layout == H5D_CHUNKED) {
             std::vector<hsize_t> chunk_dims_out(ndims);
             H5Pget_chunk(dcpl, ndims, chunk_dims_out.data());
+
             val chunks = val::array();
-            for (int c = 0; c < ndims; c++)
-            {
+            for (int c = 0; c < ndims; c++) {
                 chunks.set(c, (uint)chunk_dims_out.at(c));
             }
+
             attr.set("chunks", chunks);
         }
     }
 
-    attr.set("total_size", total_size);
     return attr;
 }
 

--- a/src/hdf5_util_helpers.d.ts
+++ b/src/hdf5_util_helpers.d.ts
@@ -19,14 +19,14 @@ export interface H5T_class_t {
 
 export interface Metadata {
     array_type?: Metadata,
-    chunks: Array<number> | null,
+    chunks: number[] | null,
     compound_type?: CompoundTypeMetadata,
     cset: number,
     enum_type?: EnumTypeMetadata,
     littleEndian: boolean,
-    maxshape: Array<number> | null,
+    maxshape: number[] | null,
     ref_type?: 'object' | 'region',
-    shape: Array<number>,
+    shape: number[] | null,
     signed: boolean,
     size: number,
     total_size: number,
@@ -40,7 +40,7 @@ export interface CompoundMember extends Metadata {
 }
 
 export interface CompoundTypeMetadata {
-    members: Array<CompoundMember>
+    members: CompoundMember[]
     nmembers: number;
 }
 
@@ -105,7 +105,7 @@ export interface H5Module extends EmscriptenModule {
     reclaim_vlen_memory(file_id: BigInt, obj_name: string, attr_name: string, data_ptr: bigint): Status;
     get_attribute_data(file_id: BigInt, obj_name: string, attr_name: string, arg3: bigint): Status;
     FS: FS.FileSystemType,
-    get_keys_vector(group_id: bigint, H5_index_t: number): Array<string>,
+    get_keys_vector(group_id: bigint, H5_index_t: number): string[],
     get_attribute_metadata(loc_id: bigint, group_name_string: string, attribute_name_string: string): Metadata,
     get_plugin_search_paths(): string[],
     insert_plugin_search_path(search_path: string, index: number): number,
@@ -116,7 +116,7 @@ export interface H5Module extends EmscriptenModule {
     get_scale_name(loc_id: bigint, dimscale_dset_name: string): string | null,
     get_attached_scales(loc_id: bigint, target_dset_name: string, index: number): string[],
     set_dimension_label(loc_id: bigint, target_dset_name: string, index: number, label: string): number,
-    get_dimension_labels(loc_id: bigint, target_dset_name: string): Array<string | null>,
+    get_dimension_labels(loc_id: bigint, target_dset_name: string): (string | null)[],
     create_object_reference(loc_id: bigint, target_name: string): Uint8Array,
     create_region_reference(file_id: bigint, path: string, count: bigint[] | null, offset: bigint[] | null, strides: bigint[] | null): Uint8Array,
     get_referenced_name(loc_id: bigint, ref_ptr: Uint8Array, is_object: boolean): string;


### PR DESCRIPTION
Currently, when encountering an empty dataset (e.g. with h5py: `grp.create_dataset("empty", dtype=np.float32)`) or an empty attribute (e.g. with h5py: `grp.attrs["empty"] = h5py.Empty(np.float32)`), `h5wasm` parses the shape as `[]` and returns the value `undefined`.

Two problems with this:

- The empty array shape is also used for scalars.
- The `undefined` value can be limiting - e.g. if you put the value in a state once you've read it, then it's difficult to know when the value has actually been read.

**With this PR, h5wasm now returns `null` shapes and `null` values for empty datasets and attributes.**

> Note that I'm only adding support for _reading_ empty datasets and attributes, not for writing them.