### PR TITLE
custom HDF5 error handler that throws error with HDF5-DIAG string

### DIFF
--- a/src/hdf5_util.cc
+++ b/src/hdf5_util.cc
@@ -16,7 +16,7 @@
 using namespace emscripten;
 
 EM_JS(void, throw_error, (const char *string_error), {
-    throw(UTF8ToString(string_error));
+    throw new Error(UTF8ToString(string_error));
 });
 
 // void throw_error(const char *string_error) {

--- a/src/hdf5_util.cc
+++ b/src/hdf5_util.cc
@@ -1219,7 +1219,19 @@ herr_t throwing_error_handler(hid_t estack, void *client_data)
     return 0;
 }
 
-herr_t error_handler_set_result = H5Eset_auto2(H5E_DEFAULT, throwing_error_handler, NULL);
+H5E_auto2_t default_error_handler;
+void *default_error_handler_client_data;
+herr_t error_handler_get_result = H5Eget_auto2(H5E_DEFAULT, &default_error_handler, &default_error_handler_client_data);
+
+int activate_throwing_error_handler() {
+    herr_t error_handler_set_result = H5Eset_auto2(H5E_DEFAULT, throwing_error_handler, NULL);
+    return (int)error_handler_set_result;
+}
+
+int deactivate_throwing_error_handler() {
+    herr_t error_handler_set_result = H5Eset_auto2(H5E_DEFAULT, default_error_handler, default_error_handler_client_data);
+    return (int)error_handler_set_result;
+}
 
 EMSCRIPTEN_BINDINGS(hdf5)
 {
@@ -1264,6 +1276,8 @@ EMSCRIPTEN_BINDINGS(hdf5)
     function("get_referenced_name", &get_referenced_name);
     function("get_region_metadata", &get_region_metadata);
     function("get_region_data", &get_region_data);
+    function("activate_throwing_error_handler", &activate_throwing_error_handler);
+    function("deactivate_throwing_error_handler", &deactivate_throwing_error_handler);
 
     class_<H5L_info2_t>("H5L_info2_t")
         .constructor<>()

--- a/src/hdf5_util_helpers.d.ts
+++ b/src/hdf5_util_helpers.d.ts
@@ -122,6 +122,8 @@ export interface H5Module extends EmscriptenModule {
     get_referenced_name(loc_id: bigint, ref_ptr: Uint8Array, is_object: boolean): string;
     get_region_metadata(loc_id: bigint, ref_ptr: Uint8Array): Metadata;
     get_region_data(loc_id: bigint, ref_data: Uint8Array, rdata_ptr: bigint): number;
+    activate_throwing_error_handler(): number;
+    deactivate_throwing_error_handler(): number;
 }
 
 export declare type Filter = {

--- a/test/nonthrowing_error_handler.mjs
+++ b/test/nonthrowing_error_handler.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { strict as assert } from 'assert';
+import { join } from 'path';
+import h5wasm from "h5wasm/node";
+
+const Module = await h5wasm.ready;
+const error_handler_set_result = Module.deactivate_throwing_error_handler();
+assert.equal(error_handler_set_result, 0); // success
+
+const PATH = join(".", "test", "tmp");
+const FILEPATH = join(PATH, "nonexistant_file.h5");
+
+function open_nonexistant_file() {
+  const file = new h5wasm.File(FILEPATH, "r");
+  return file;
+}
+
+const file = open_nonexistant_file();
+

--- a/test/nonthrowing_error_handler.mjs
+++ b/test/nonthrowing_error_handler.mjs
@@ -16,4 +16,3 @@ function open_nonexistant_file() {
 }
 
 const file = open_nonexistant_file();
-

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -16,6 +16,7 @@ import create_compressed from './create_read_compressed.mjs';
 import dimension_labels from './dimension_labels.mjs';
 import dimension_scales from './dimension_scales.mjs';
 import references from './create_read_references.mjs';
+import test_throwing_error_handler from './test_throwing_error_handler.mjs';
 
 let tests = [];
 const add_tests = (tests_in) => { /*global*/ tests = tests.concat(tests_in)}
@@ -35,6 +36,7 @@ add_tests(create_compressed);
 add_tests(dimension_labels);
 add_tests(dimension_scales);
 add_tests(references);
+add_tests(test_throwing_error_handler);
 
 let passed = true;
 async function run_test(test) {

--- a/test/test_throwing_error_handler.mjs
+++ b/test/test_throwing_error_handler.mjs
@@ -34,7 +34,9 @@ async function test_default_error_handler() {
   // verify that the default error handler does not throw,
   // and that it prints an error message to stderr
   const child_process = spawnSync("/usr/bin/env", ["node", "test/nonthrowing_error_handler.mjs"]);
-  const { stderr } = child_process;
+  const { stderr, status } = child_process;
+  // status should be zero, no error thrown:
+  assert.strictEqual(status, 0);
   const error_message = stderr.toString();
   const lines = error_message.split("\n");
   assert(lines.length > 2, "error message should have more than 2 lines");

--- a/test/test_throwing_error_handler.mjs
+++ b/test/test_throwing_error_handler.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import { strict as assert } from 'assert';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+import h5wasm from "h5wasm/node";
+
+async function test_throwing_error_handler() {
+  const Module = await h5wasm.ready;
+  const error_handler_set_result = Module.activate_throwing_error_handler();
+  assert.equal(error_handler_set_result, 0); // success
+
+  const PATH = join(".", "test", "tmp");
+  const FILEPATH = join(PATH, "nonexistant_file.h5");
+
+  function open_nonexistant_file() {
+    const file = new h5wasm.File(FILEPATH, "r");
+    return file;
+  }
+  // assert.throws(open_nonexistant_file, Error);
+
+  let error_message = "no error";
+  try {
+    const file = open_nonexistant_file();
+  }
+  catch (e) {
+    error_message = e;
+  }
+  const lines = error_message.split("\n");
+  assert(lines.length > 2, "error message should have more than 2 lines");
+  const expected_error_message = "H5Fopen(): unable to synchronously open file";
+  assert(lines[1].endsWith(expected_error_message), "unexpected error message: " + lines[1]);
+}
+
+async function test_default_error_handler() {
+  // verify that the default error handler does not throw,
+  // and that it prints an error message to stderr
+  const child_process = spawnSync("/usr/bin/env", ["node", "test/nonthrowing_error_handler.mjs"]);
+  const { stderr } = child_process;
+  const error_message = stderr.toString();
+  const lines = error_message.split("\n");
+  assert(lines.length > 2, "error message should have more than 2 lines");
+  const expected_error_message = "H5Fopen(): unable to synchronously open file";
+  assert(lines[1].endsWith(expected_error_message), "unexpected error message: " + lines[1]);
+}
+
+export const tests = [
+  {
+    description: "test throwing error handler",
+    test: test_throwing_error_handler
+  },
+  {
+    description: "test default error handler",
+    test: test_default_error_handler
+  }
+];
+
+export default tests;

--- a/test/test_throwing_error_handler.mjs
+++ b/test/test_throwing_error_handler.mjs
@@ -16,14 +16,13 @@ async function test_throwing_error_handler() {
     const file = new h5wasm.File(FILEPATH, "r");
     return file;
   }
-  // assert.throws(open_nonexistant_file, Error);
 
   let error_message = "no error";
   try {
     const file = open_nonexistant_file();
   }
   catch (e) {
-    error_message = e;
+    error_message = e.toString();
   }
   const lines = error_message.split("\n");
   assert(lines.length > 2, "error message should have more than 2 lines");


### PR DESCRIPTION
The current behavior of the C API code is to print any errors to `stderr`, which results in the stack trace being printed in the browser console using `console.error()` (see https://github.com/emscripten-core/emscripten/blob/6105e7654f66964ad9de0d065f3797923736d4ef/src/shell.js#L436)

This PR adds a custom error handler function to hdf5_util.cc, and adds these functions to `h5wasm.Module`;

- `activate_throwing_error_handler(): number; // returns 0 on success`
- `deactivate_throwing_error_handler(): number; // returns 0 on success`, which restores original stderr behavior

to use: 
```javascript
import h5wasm from "h5wasm";
const Module = await h5wasm.ready;
Module.activate_throwing_error_handler();
// after this, any errors in HDF5 library will throw a Javascript error with stack trace...
```