### PR TITLE
Fix missing extension in type import

### DIFF
--- a/src/hdf5_hl.d.ts
+++ b/src/hdf5_hl.d.ts
@@ -1,4 +1,4 @@
-import type { Status, Metadata, H5Module, CompoundMember, CompoundTypeMetadata, EnumTypeMetadata, Filter } from "./hdf5_util_helpers";
+import type { Status, Metadata, H5Module, CompoundMember, CompoundTypeMetadata, EnumTypeMetadata, Filter } from "./hdf5_util_helpers.js";
 export declare var Module: H5Module;
 export declare var FS: (FS.FileSystemType | null);
 declare const ready: Promise<H5Module>;

--- a/src/hdf5_hl.ts
+++ b/src/hdf5_hl.ts
@@ -1,4 +1,4 @@
-import type {Status, Metadata, H5Module, CompoundMember, CompoundTypeMetadata, EnumTypeMetadata, Filter} from "./hdf5_util_helpers";
+import type {Status, Metadata, H5Module, CompoundMember, CompoundTypeMetadata, EnumTypeMetadata, Filter} from "./hdf5_util_helpers.js";
 
 import ModuleFactory from './hdf5_util.js';
 


### PR DESCRIPTION
I think it's all it takes to address https://github.com/usnistgov/h5wasm/issues/31#issuecomment-2032301488. The other imports have the JS extension; it was only missing on the `type` import. I did a quick local check with `moduleResolution: bundler` and nothing broke – haven't tried with `moduleResolution: nodenext` but given the error message, I'm fairly confident that's the fix.

