### PR TITLE
Strpad in metadata

### DIFF
--- a/src/hdf5_util.cc
+++ b/src/hdf5_util.cc
@@ -261,10 +261,7 @@ val get_dtype_metadata(hid_t dtype)
     if (dtype_class == H5T_STRING)
     {
         attr.set("cset", (int)(H5Tget_cset(dtype)));
-    }
-    else
-    {
-        attr.set("cset", -1);
+        attr.set("strpad", (int)(H5Tget_strpad(dtype)));
     }
 
     if (dtype_class == H5T_COMPOUND)
@@ -1317,6 +1314,12 @@ EMSCRIPTEN_BINDINGS(hdf5)
         .value("H5T_ENUM", H5T_ENUM)           //      = 8,  /**< enumeration types                       */
         .value("H5T_VLEN", H5T_VLEN)           //      = 9,  /**< variable-Length types                   */
         .value("H5T_ARRAY", H5T_ARRAY)         //     = 10, /**< array types                             */
+        ;
+    enum_<H5T_str_t>("H5T_str_t")
+        .value("H5T_STR_ERROR", H5T_STR_ERROR) // = -1, /**<error                                      */
+        .value("H5T_STR_NULLTERM", H5T_STR_NULLTERM) // = 0, /**<null-terminated                           */
+        .value("H5T_STR_NULLPAD", H5T_STR_NULLPAD) // = 1, /**<pad with nulls                            */
+        .value("H5T_STR_SPACEPAD", H5T_STR_SPACEPAD) // = 2, /**<pad with spaces                           */
         ;
 
     //constant("H5L_type_t", H5L_type_t);

--- a/src/hdf5_util_helpers.d.ts
+++ b/src/hdf5_util_helpers.d.ts
@@ -17,11 +17,19 @@ export interface H5T_class_t {
     H5T_ARRAY: {value: 10}         // = 10, /**< array types                             */
 }
 
+export interface H5T_str_t {
+    H5T_STR_ERROR: {value: -1},    // = -1, /**< error */
+    H5T_STR_NULLTERM: {value: 0},  // = 0, /**< null-terminated, null-padding */
+    H5T_STR_NULLPAD: {value: 1},   // = 1, /**< null-terminated, null-padding */
+    H5T_STR_SPACEPAD: {value: 2},  // = 2, /**< space-padding */
+    H5T_STR_RESERVED_3: {value: 3} // = 3  /**< reserved for future use */
+}
+
 export interface Metadata {
     array_type?: Metadata,
     chunks: number[] | null,
     compound_type?: CompoundTypeMetadata,
-    cset: number,
+    cset?: number,
     enum_type?: EnumTypeMetadata,
     littleEndian: boolean,
     maxshape: number[] | null,
@@ -29,6 +37,7 @@ export interface Metadata {
     shape: number[] | null,
     signed: boolean,
     size: number,
+    strpad?: H5T_str_t,
     total_size: number,
     type: number,
     vlen: boolean,

--- a/test/bool_test.mjs
+++ b/test/bool_test.mjs
@@ -14,7 +14,6 @@ async function bool_test() {
 
   assert.deepEqual(f.get('bool').metadata, {
     chunks: null,
-    cset: -1,
     enum_type: {
       type: 0,
       nmembers: 2,

--- a/test/compound_and_array_test.mjs
+++ b/test/compound_and_array_test.mjs
@@ -67,7 +67,6 @@ async function compound_array_test() {
       members: [
         {
           array_type: {
-            cset: -1,
             shape: [2, 2],
             littleEndian: true,
             signed: false,
@@ -76,7 +75,6 @@ async function compound_array_test() {
             type: 1,
             vlen: false,
           },
-          cset: -1,
           littleEndian: true,
           name: 'floaty',
           offset: 0,
@@ -93,11 +91,11 @@ async function compound_array_test() {
             littleEndian: false,
             signed: false,
             size: 5,
+            strpad: 1,
             total_size: 4,
             type: 3,
             vlen: false,
           },
-          cset: -1,
           littleEndian: false,
           name: 'stringy',
           offset: 32,
@@ -110,7 +108,6 @@ async function compound_array_test() {
       ],
       nmembers: 2
     },
-    cset: -1,
     littleEndian: true,
     maxshape: [2],
     shape: [2],


### PR DESCRIPTION
Adds a `strpad` property to `Metadata` object for Dataset or Attribute.

Removes `cset` property from `Metadata` for non-string dtypes (change in behavior, tests altered).