### PR TITLE
Don't convert boolean enums unless JSON compatibility is requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Changelog
+## v0.7.6
+### Changed
+ - Retrieve `value` of boolean dataset as `Int8Array` instead of plain JS boolean array. To retrieve a plain JS boolean array, use `json_value` instead:
+ 
+   ```ts
+   // v0.7.5 and earlier
+   bool_dset.value; // -> [false, true]
+   bool_dset.json_value; // -> [false, true]
+
+   // v0.7.6 onwards
+   bool_dset.value; // -> Int8Array(2) [0, 1]
+   bool_dset.json_value; // -> [false, true]
+   ```
 ## v0.7.5 2024-06-03
 ### Added
  - added `virtual_sources?: { file_name: string, dset_name: string }` to `Dataset.metadata` when dataset is virtual.

--- a/src/hdf5_hl.ts
+++ b/src/hdf5_hl.ts
@@ -188,7 +188,7 @@ function process_data(data: Uint8Array, metadata: Metadata, json_compatible: boo
     output_data = process_data(data, base_metadata, json_compatible);
     // Following the convention of h5py, treat all enum datasets where the
     // enum members are ["FALSE", "TRUE"] as boolean arrays
-    if (isH5PYBooleanEnum(metadata.enum_type as EnumTypeMetadata)) {
+    if (json_compatible && isH5PYBooleanEnum(metadata.enum_type as EnumTypeMetadata)) {
       if (isIterable(output_data)) {
         output_data = [...output_data].map((x) => !!x);
       }

--- a/test/bool_test.mjs
+++ b/test/bool_test.mjs
@@ -9,6 +9,11 @@ async function bool_test() {
 
   assert.deepEqual(
     f.get('bool').value,
+    new Int8Array([ 0, 1, 1, 0 ])
+  );
+
+  assert.deepEqual(
+    f.get('bool').json_value,
     [ false, true, true, false ]
   );
 


### PR DESCRIPTION
H5Web supports plotting boolean datasets:

![image](https://github.com/user-attachments/assets/87e9d828-0b32-41c3-a26f-0ba867b10589)

Currently, h5wasm converts boolean enum arrays, which are read as numeric typed arrays by the HDF5 library, to plain JS boolean arrays. This means that in H5Web, I have to convert those boolean arrays back to numeric arrays before I can plot them.

In this PR, I'm proposing to no longer convert boolean enum arrays when `json_compatible` is `false` - i.e. to convert them only when JSON-compatible data is requested.