### PR TITLE
Add `close_file` method to Module API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## v0.7.8 TBC
+### Added
+- Add `close_file` method to Module API: `close_file(file_id: bigint): number;`
 ### Fixed
 - Fix accessing attributes of committed datatype with `my_datafile.attrs`.
 - Fix calling `get_attribute_names` method of Module API on committed datatype.

--- a/src/hdf5_hl.ts
+++ b/src/hdf5_hl.ts
@@ -899,7 +899,7 @@ export class File extends Group {
   }
 
   close(): Status {
-    return Module.ccall("H5Fclose", "number", ["bigint"], [this.file_id]);
+    return Module.close_file(this.file_id);
   }
 }
 

--- a/src/hdf5_util.cc
+++ b/src/hdf5_util.cc
@@ -52,6 +52,12 @@ int64_t open(const std::string& filename_string, unsigned int h5_mode = H5F_ACC_
     return (int64_t)file_id;
 }
 
+int close_file(hid_t file_id)
+{
+    herr_t status = H5Fclose(file_id);
+    return (int)status;
+}
+
 herr_t link_name_callback(hid_t loc_id, const char *name, const H5L_info_t *linfo, void *opdata)
 {
     std::vector<std::string> *namelist = reinterpret_cast<std::vector<std::string> *>(opdata);
@@ -1329,6 +1335,7 @@ int deactivate_throwing_error_handler() {
 EMSCRIPTEN_BINDINGS(hdf5)
 {
     function("open", &open);
+    function("close_file", &close_file);
     function("get_keys", &get_keys_vector);
     function("get_names", &get_child_names);
     function("get_types", &get_child_types);

--- a/src/hdf5_util_helpers.d.ts
+++ b/src/hdf5_util_helpers.d.ts
@@ -60,6 +60,7 @@ export interface VirtualSource {
 
 export interface H5Module extends EmscriptenModule {
     open(filename: string, mode?: number, track_order?: boolean): bigint;
+    close_file(file_id: bigint): number;
     create_dataset(file_id: bigint, arg1: string, arg2: bigint, shape: bigint[], maxshape: (bigint | null)[], chunks: bigint[] | null, type: number, size: number, signed: boolean, vlen: boolean, compression_id: number, compression_opts: number[], track_order?: boolean): number;
     create_soft_link(file_id: bigint, link_target: string, link_name: string): number;
     create_hard_link(file_id: bigint, link_target: string, link_name: string): number;


### PR DESCRIPTION
I use the Module API directly in H5Web, because of the web worker, and this will remove the only remaining `ccall` invocation.