### PR TITLE
Add `Uint8ClampedArray` to `TypedArray_to_dtype` mapping

### DIFF
--- a/src/hdf5_hl.ts
+++ b/src/hdf5_hl.ts
@@ -442,6 +442,7 @@ type TypedArrayConstructor =
 
 const TypedArray_to_dtype = new Map([
   ['Uint8Array', '<B'],
+  ['Uint8ClampedArray', '<B'],
   ['Uint16Array', '<H'],
   ['Uint32Array', '<I'],
   ['BigUint64Array', '<Q'],


### PR DESCRIPTION
When calling `create_dataset` with `data` that is a `Uint8ClampedArray`, the library throws the error `"DataView not supported directly for write"`.

This appears to be because the `TypedArray_to_dtype` is missing a mapping for that array type, even though it is a permissible array type based on the `GuessableDataTypes` and `TypedArray` types.

This PR updates the mapping so `Uint8ClampedArray`s can be provided as the `data` parameter to `create_dataset`.