### PR TITLE
update to new build of libhdf5-wasm, built with emscripten 3.1.68

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,13 @@ project(H5WASM
     LANGUAGES CXX C
 )
 
-set (BASE_URL "https://github.com/usnistgov/libhdf5-wasm/releases/download/v0.4.3_3.1.43" CACHE STRING "")
+set (BASE_URL "https://github.com/usnistgov/libhdf5-wasm/releases/download/v0.4.6_3.1.68" CACHE STRING "")
 # set (BASE_URL "$ENV{HOME}/dev/libhdf5-wasm" CACHE STRING "")
 
 FetchContent_Declare(
   libhdf5-wasm
-  URL ${BASE_URL}/HDF5-1.14.2-Emscripten.tar.gz
-  URL_HASH SHA256=7299eda21bd0fbe85bccdf76ee4636bae12db1295d9ac9b75f800ff3f825a2c6
+  URL ${BASE_URL}/HDF5-1.14.6-Emscripten.tar.gz
+  URL_HASH SHA256=0c5de36a3c81e3854e57593c55274d89a43db3f8a7bbe6a0d9d5c560e9c222b1
 )
 if (NOT libhdf5-wasm_POPULATED)
   FetchContent_MakeAvailable(libhdf5-wasm)


### PR DESCRIPTION
Changes:

- now using HDF5 version 1.14.6
- built with Emscripten version 3.1.68