### PR TITLE
add export symbols needed by JPEG compression filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ list (APPEND EXPORTED_FUNCTIONS
     H5allocate_memory H5free_memory 
     pthread_mutex_init posix_memalign strcmp getenv 
     stdin stdout stderr
+    H5Epush2 siprintf
     H5E_ERR_CLS_g H5E_PLINE_g H5E_CANTINIT_g H5E_CANTGET_g H5E_CANTFILTER_g 
     H5E_BADTYPE_g H5E_BADVALUE_g H5E_ARGS_g H5E_CALLBACK_g H5E_CANTREGISTER_g 
     H5E_RESOURCE_g H5E_NOSPACE_g H5E_OVERFLOW_g H5E_READERROR_g 


### PR DESCRIPTION
We need to add the `H5Epush2` and `siprintf` symbols, which are used by the JPEG compression filter (indirectly)
