### PR TITLE
Support write subarray

### DIFF
--- a/src/hdf5_hl.ts
+++ b/src/hdf5_hl.ts
@@ -390,7 +390,7 @@ function prepare_data(data: any, metadata: Metadata, shape?: number[] | bigint[]
       }
       typed_array = new accessor(data);
     }
-    output = new Uint8Array(typed_array.buffer);
+    output = new Uint8Array(typed_array.buffer, typed_array.byteOffset, typed_array.byteLength);
   }
   else if (metadata.type === Module.H5T_class_t.H5T_REFERENCE.value) {
     output = new Uint8Array(metadata.size * total_size);

--- a/test/subarray_write_test.mjs
+++ b/test/subarray_write_test.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+import { strict as assert } from 'assert';
+import { existsSync, mkdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import h5wasm from "h5wasm/node";
+
+async function subarray_write_test() {
+  await h5wasm.ready;
+  const PATH = join('.', 'test', 'tmp');
+  const FILEPATH = join(PATH, 'subarray_write.h5');
+  const DSET_NAME = 'subarray';
+  const DTYPE = '<f4';
+  const SHAPE = [2, 2];
+  const INITIAL = [0, 0, 0, 0];
+
+  if (!existsSync(PATH)) {
+    mkdirSync(PATH);
+  }
+
+  const write_file = new h5wasm.File(FILEPATH, 'w');
+  const dset = write_file.create_dataset({
+    name: DSET_NAME,
+    data: INITIAL,
+    shape: SHAPE,
+    dtype: DTYPE,
+  });
+
+  const source = new Float32Array([1, 2, 3, 4, 10, 20, 30, 40]);
+  const chunk = source.subarray(4, 8); // expected [10,20,30,40]
+  dset.write_slice([[0, 2], []], chunk);
+
+  assert.deepEqual([...dset.value].map(Number), [10, 20, 30, 40]);
+
+  write_file.flush();
+  write_file.close();
+
+  // cleanup
+  unlinkSync(FILEPATH);
+}
+
+export const tests = [
+  {
+    description: "Write slice using TypedArray.subarray",
+    test: subarray_write_test,
+  },
+];
+
+export default tests;

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -23,6 +23,7 @@ import track_order from './track_order.mjs';
 import libver_test from './libver_test.mjs';
 import swmr_test from './swmr_test.mjs';
 import compound_write from './create_compound_dataset.mjs';
+import subarray_write_test from './subarray_write_test.mjs';
 
 let tests = [];
 const add_tests = (tests_in) => { /*global*/ tests = tests.concat(tests_in)}
@@ -49,6 +50,7 @@ add_tests(track_order);
 add_tests(libver_test);
 add_tests(swmr_test);
 add_tests(compound_write);
+add_tests(subarray_write_test);
 
 let passed = true;
 async function run_test(test) {


### PR DESCRIPTION
The `byteOffset` and `byteLength` arguments for `TypedArray` views weren't being passed to the constructor for the `Uint8Array` view that is used to prepare data for writing.

This PR adds those arguments.  Should fix #130 