### PR TITLE
Integer precision and ascii string fix

### DIFF
--- a/src/hdf5_hl.ts
+++ b/src/hdf5_hl.ts
@@ -449,7 +449,8 @@ function metadata_to_dtype(metadata: Metadata): Dtype {
   const { type, size, littleEndian, signed, compound_type, array_type, vlen } = metadata;
   if (type == Module.H5T_class_t.H5T_STRING.value) {
     let length_str = vlen ? "" : String(size);
-    return `S${length_str}`;
+    const prefix = (metadata.cset === 0) ? 'A' : 'S';
+    return `${prefix}${length_str}`;
   }
   else if (type == Module.H5T_class_t.H5T_INTEGER.value) {
     let fmt = int_fmts.get(size);
@@ -490,13 +491,14 @@ export function dtype_to_metadata(dtype: Dtype): Metadata {
   let metadata = { vlen: false, signed: false, littleEndian: true } as Metadata;
 
   if (typeof dtype === 'string') {
-    // Simple string dtype: '<i8', '<f4', 'S10', 'Reference', etc.
+    // Simple string dtype: '<i8', '<f4', 'S10', 'A10', 'Reference', etc.
+    // 'S' = UTF-8 string (FORTRAN_S1, SPACEPAD), 'A' = ASCII string (C_S1, NULLTERM)
     if (dtype === "Reference" || dtype === "RegionReference") {
       metadata.type = Module.H5T_class_t.H5T_REFERENCE.value;
       metadata.size = (dtype === "Reference") ? Module.SIZEOF_OBJ_REF : Module.SIZEOF_DSET_REGION_REF;
     }
     else {
-      const match = dtype.match(/^([<>|]?)([bhiqefdsBHIQS])([0-9]*)$/);
+      const match = dtype.match(/^([<>|]?)([bhiqefdsBHIQSaA])([0-9]*)$/);
       if (match == null) {
         throw dtype + " is not a recognized dtype";
       }
@@ -511,10 +513,11 @@ export function dtype_to_metadata(dtype: Dtype): Metadata {
         metadata.type = Module.H5T_class_t.H5T_FLOAT.value;
         metadata.size = (fmts_float.get(typestr) as number);
       }
-      else if (typestr.toUpperCase() === 'S') {
+      else if (typestr.toUpperCase() === 'S' || typestr.toUpperCase() === 'A') {
         metadata.type = Module.H5T_class_t.H5T_STRING.value;
         metadata.size = (length == "") ? 4 : parseInt(length, 10);
         metadata.vlen = (length == "");
+        metadata.cset = (typestr.toUpperCase() === 'A') ? 0 : 1;
       }
       else {
         throw "should never happen";

--- a/src/hdf5_util.cc
+++ b/src/hdf5_util.cc
@@ -787,9 +787,16 @@ hid_t create_h5_datatype_from_metadata(val metadata) {
 
     if (dtype == H5T_STRING) {
         size_t str_size = (is_vlstr) ? H5T_VARIABLE : dsize;
-        filetype = H5Tcopy(H5T_FORTRAN_S1);
-        H5Tset_size(filetype, str_size);
-        H5Tset_cset(filetype, H5T_CSET_UTF8);
+        int cset = metadata["cset"].isUndefined() ? H5T_CSET_UTF8 : metadata["cset"].as<int>();
+        if (cset == H5T_CSET_ASCII) {
+            filetype = H5Tcopy(H5T_C_S1);
+            H5Tset_size(filetype, str_size);
+            H5Tset_cset(filetype, H5T_CSET_ASCII);
+        } else {
+            filetype = H5Tcopy(H5T_FORTRAN_S1);
+            H5Tset_size(filetype, str_size);
+            H5Tset_cset(filetype, H5T_CSET_UTF8);
+        }
     }
     else if (dtype == H5T_INTEGER) {
         filetype = H5Tcopy(H5T_NATIVE_INT);

--- a/src/hdf5_util.cc
+++ b/src/hdf5_util.cc
@@ -794,6 +794,7 @@ hid_t create_h5_datatype_from_metadata(val metadata) {
     else if (dtype == H5T_INTEGER) {
         filetype = H5Tcopy(H5T_NATIVE_INT);
         H5Tset_size(filetype, dsize);
+        H5Tset_precision(filetype, dsize * 8);
         H5Tset_sign(filetype, (H5T_sign_t)is_signed);
     }
     else if (dtype == H5T_FLOAT) {

--- a/test/string_cset_test.mjs
+++ b/test/string_cset_test.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+import { strict as assert } from 'assert';
+import { existsSync, mkdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import h5wasm, { dtype_to_metadata } from "h5wasm/node";
+
+async function ascii_string_attribute() {
+  await h5wasm.ready;
+  const PATH = join(".", "test", "tmp");
+  const FILEPATH = join(PATH, "cset_attr.h5");
+
+  if (!(existsSync(PATH))) {
+    mkdirSync(PATH);
+  }
+
+  const write_file = new h5wasm.File(FILEPATH, "w");
+  write_file.create_attribute("ascii_attr", "hello", null, "A5");
+  write_file.create_attribute("utf8_attr", "world", null, "S5");
+  write_file.create_attribute("default_attr", "test");
+  write_file.flush();
+  write_file.close();
+
+  const read_file = new h5wasm.File(FILEPATH, "r");
+
+  const ascii_meta = read_file.attrs["ascii_attr"].metadata;
+  assert.equal(ascii_meta.cset, 0, "ASCII attr cset should be 0");
+  assert.equal(read_file.attrs["ascii_attr"].value, "hello");
+
+  const utf8_meta = read_file.attrs["utf8_attr"].metadata;
+  assert.equal(utf8_meta.cset, 1, "UTF-8 attr cset should be 1");
+  assert.equal(read_file.attrs["utf8_attr"].value, "world");
+
+  const default_meta = read_file.attrs["default_attr"].metadata;
+  assert.equal(default_meta.cset, 1, "Default attr cset should be 1 (UTF-8)");
+  assert.equal(read_file.attrs["default_attr"].value, "test");
+
+  read_file.close();
+  unlinkSync(FILEPATH);
+}
+
+async function ascii_string_dataset() {
+  await h5wasm.ready;
+  const PATH = join(".", "test", "tmp");
+  const FILEPATH = join(PATH, "cset_dset.h5");
+
+  if (!(existsSync(PATH))) {
+    mkdirSync(PATH);
+  }
+
+  const write_file = new h5wasm.File(FILEPATH, "w");
+  write_file.create_dataset({ name: "ascii_fixed", data: ["abc", "def"], dtype: "A3" });
+  write_file.create_dataset({ name: "utf8_fixed", data: ["abc", "def"], dtype: "S3" });
+  write_file.create_dataset({ name: "default_vlen", data: ["abc", "def"] });
+  write_file.flush();
+  write_file.close();
+
+  const read_file = new h5wasm.File(FILEPATH, "r");
+
+  const ascii_dset = read_file.get("ascii_fixed");
+  assert.equal(ascii_dset.dtype, "A3", "ASCII dataset dtype should be A3");
+  assert.equal(ascii_dset.metadata.cset, 0, "ASCII dataset cset should be 0");
+
+  const utf8_dset = read_file.get("utf8_fixed");
+  assert.equal(utf8_dset.dtype, "S3", "UTF-8 dataset dtype should be S3");
+  assert.equal(utf8_dset.metadata.cset, 1, "UTF-8 dataset cset should be 1");
+
+  const default_dset = read_file.get("default_vlen");
+  assert.equal(default_dset.metadata.cset, 1, "Default dataset cset should be 1 (UTF-8)");
+  assert.deepEqual(default_dset.value, ["abc", "def"]);
+
+  read_file.close();
+  unlinkSync(FILEPATH);
+}
+
+async function ascii_dtype_roundtrip() {
+  await h5wasm.ready;
+
+  const a_meta = dtype_to_metadata("A16");
+  assert.equal(a_meta.type, 3, "A16 type should be H5T_STRING (3)");
+  assert.equal(a_meta.size, 16);
+  assert.equal(a_meta.cset, 0, "A16 cset should be 0 (ASCII)");
+  assert.equal(a_meta.vlen, false);
+
+  const s_meta = dtype_to_metadata("S16");
+  assert.equal(s_meta.type, 3);
+  assert.equal(s_meta.size, 16);
+  assert.equal(s_meta.cset, 1, "S16 cset should be 1 (UTF-8)");
+  assert.equal(s_meta.vlen, false);
+
+  const vlen_meta = dtype_to_metadata("S");
+  assert.equal(vlen_meta.vlen, true, "S without length should be vlen");
+  assert.equal(vlen_meta.cset, 1);
+}
+
+export const tests = [
+  {
+    description: "Create ASCII and UTF-8 string attributes with cset parameter",
+    test: ascii_string_attribute
+  },
+  {
+    description: "Create ASCII and UTF-8 string datasets with cset parameter",
+    test: ascii_string_dataset
+  },
+  {
+    description: "dtype_to_metadata roundtrip for A and S prefixes",
+    test: ascii_dtype_roundtrip
+  }
+];
+export default tests;

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -24,6 +24,7 @@ import libver_test from './libver_test.mjs';
 import swmr_test from './swmr_test.mjs';
 import compound_write from './create_compound_dataset.mjs';
 import subarray_write_test from './subarray_write_test.mjs';
+import string_cset_test from './string_cset_test.mjs';
 
 let tests = [];
 const add_tests = (tests_in) => { /*global*/ tests = tests.concat(tests_in)}
@@ -51,6 +52,7 @@ add_tests(libver_test);
 add_tests(swmr_test);
 add_tests(compound_write);
 add_tests(subarray_write_test);
+add_tests(string_cset_test);
 
 let passed = true;
 async function run_test(test) {


### PR DESCRIPTION
## Problem

`create_h5_datatype_from_metadata()` in `hdf5_util.cc` produces non-standard HDF5 type descriptors when compiled for wasm32 via Emscripten. The resulting files are valid HDF5 but are rejected by third-party readers (VTK/ParaView, HDFView, h5py strict mode). h5wasm's own round-trip tests pass because its read path tolerates the non-standard types.

### Bug 1 — Integer precision mismatch

`H5T_NATIVE_INT` is 32-bit on wasm32. When `H5Tset_size(filetype, 8)` widens storage to 64 bits, precision remains 32. The file contains:

```
DATATYPE  64-bit little-endian integer 32-bit precision
```

instead of `H5T_STD_I64LE`. VTK and h5py reject this.

### Bug 2 — String type uses FORTRAN convention and UTF-8

The existing code uses `H5T_FORTRAN_S1` with `H5T_CSET_UTF8`, producing `SPACEPAD + UTF-8` strings. Most HDF5 consumers (VTK, h5py, HDFView) expect `H5T_C_S1` with `H5T_CSET_ASCII` (`NULLTERM + ASCII`), which is the C library default.

## Fix

### Integer

Add `H5Tset_precision(filetype, dsize * 8)` after `H5Tset_size`. This is the minimal correct fix — the precision field must match the storage size.

### String

Rather than changing the default and breaking existing users, the string type is made **parameterizable** via the existing `metadata.cset` field:

| `metadata.cset` | Base type | Charset | Padding | dtype prefix |
|---|---|---|---|---|
| `undefined` / `1` | `H5T_FORTRAN_S1` | `H5T_CSET_UTF8` | `H5T_STR_SPACEPAD` | `S` (unchanged) |
| `0` | `H5T_C_S1` | `H5T_CSET_ASCII` | `H5T_STR_NULLTERM` | `A` (new) |

**JS API:**

- `'S16'` — fixed-length UTF-8 string, 16 bytes (existing behavior, default)
- `'A16'` — fixed-length ASCII string, 16 bytes (new, matches h5py/C defaults)
- `'S'` — variable-length UTF-8 string (existing behavior, default for guessed strings)

**Backwards compatibility:** `S` dtype, `guess_metadata`, and omitted `cset` all produce the same output as before. Only explicit use of the `A` prefix or `cset: 0` in metadata selects the C/ASCII convention.

`metadata_to_dtype` returns `'A'` when reading back a dataset/attribute with `cset === 0`, so round-trips are consistent.

## Tests

3 new tests in `test/string_cset_test.mjs`:

- Write and read back ASCII vs UTF-8 string attributes, verify `cset` metadata
- Write and read back ASCII vs UTF-8 string datasets, verify `dtype` prefix
- `dtype_to_metadata` roundtrip for `A` and `S` prefixes

All 44 existing + new tests pass. Existing tests are unaffected.

## Verification

Confirmed with `h5dump -pH` that files using `A` dtype produce standard types:

| Before | After (`A` dtype) |
|---|---|
| `H5T_STR_SPACEPAD; H5T_CSET_UTF8` | `H5T_STR_NULLTERM; H5T_CSET_ASCII` |
| `64-bit LE integer 32-bit precision` | `H5T_STD_I64LE` |

ParaView (`pvpython`) opens files produced with the integer fix + `A` dtype. Files from the unpatched build are rejected.
