### PR TITLE
Add H5WASM_ALLOW_DYNAMIC_EXECUTION option to enable H5PL plugin dlopen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,27 @@ endif()
 set(HDF5_DIR ${libhdf5-wasm_SOURCE_DIR}/cmake)
 find_package(HDF5 REQUIRED CONFIG)
 
+# Whether to allow eval-based dynamic execution (DYNAMIC_EXECUTION=1).
+# This is required for libhdf5's H5PL_load() to dlopen filter plugin .so
+# files from the WASM filesystem. Without it, every external filter plugin
+# (blosc2, zstd, bitshuffle, lz4, bz2, jpeg, zfp, bitround, bitgroom)
+# silently fails to decode and returns garbage bytes — see
+# the issue body for a minimal repro.
+#
+# Default OFF preserves the strict-CSP behavior introduced in PR #106
+# (no 'unsafe-eval' needed). Builds for environments that need full
+# h5wasm-plugins codec support should set this ON:
+#     emcmake cmake .. -DH5WASM_ALLOW_DYNAMIC_EXECUTION=ON
+option(H5WASM_ALLOW_DYNAMIC_EXECUTION
+       "Allow eval-based dynamic execution (required for H5PL plugin dlopen)"
+       OFF)
+if (H5WASM_ALLOW_DYNAMIC_EXECUTION)
+    set(DYNAMIC_EXECUTION_FLAG "-s DYNAMIC_EXECUTION=1")
+else()
+    set(DYNAMIC_EXECUTION_FLAG "-s DYNAMIC_EXECUTION=0")
+endif()
+
+
 add_executable(hdf5_util src/hdf5_util.cc)
 target_link_libraries(hdf5_util hdf5::hdf5_hl-static)
 
@@ -61,7 +82,7 @@ set_target_properties(hdf5_util PROPERTIES
     -s MAIN_MODULE=2 \
     -s ALLOW_TABLE_GROWTH=1 \
     -s ALLOW_MEMORY_GROWTH=1 \
-    -s DYNAMIC_EXECUTION=0 \
+    ${DYNAMIC_EXECUTION_FLAG} \
     -s STACK_SIZE=2097152 \
     -s WASM_BIGINT \
     -s ENVIRONMENT=web,worker \
@@ -84,7 +105,7 @@ set_target_properties(hdf5_util_node PROPERTIES
     -s NODEJS_CATCH_REJECTION=0 \
     -s ALLOW_TABLE_GROWTH=1 \
     -s ALLOW_MEMORY_GROWTH=1 \
-    -s DYNAMIC_EXECUTION=0 \
+    ${DYNAMIC_EXECUTION_FLAG} \
     -s STACK_SIZE=2097152 \
     -s WASM_BIGINT \
     -s NODERAWFS=1 \


### PR DESCRIPTION
## Summary

Setting `-s DYNAMIC_EXECUTION=0` (introduced in #106 for strict-CSP environments) silently breaks libhdf5's ability to `dlopen` filter plugin `.so` files from the WASM filesystem in the ESM/MEMFS build. This affects every external filter shipped by `h5wasm-plugins` — **blosc2, zstd, bitshuffle, lz4, bz2, jpeg, zfp, bitround, bitgroom**. Reads silently return garbage bytes; no exception, no API-visible error.

This PR adds a CMake option `H5WASM_ALLOW_DYNAMIC_EXECUTION` (default **OFF** — preserves current behavior). Builds that need plugin codec support set it `ON`:

```sh
emcmake cmake .. -DH5WASM_ALLOW_DYNAMIC_EXECUTION=ON
```

No behavior change for existing consumers.

## What's actually happening

When `H5Dread` hits a chunk compressed with a non-built-in filter, libhdf5 calls `H5PL_load()` → `H5PL__open()` → emscripten's `dlopen()`. With `DYNAMIC_EXECUTION=0` (which sets `-sNO_DYNAMIC_EXECUTION`), the dynamic linker can't perform the symbol-binding step. Activating the throwing error handler shows:

```
HDF5-DIAG: Error detected in HDF5 (1.14.6):
  #000: H5Dio.c line ... in H5Dread(): can't read data
  ...
  #008: H5PL_load(): can't find plugin
  #009: bad export type for 'H5_libterm_g': undefined
```

But without `activate_throwing_error_handler()`, the default behavior is **silent corruption** — `Dataset.value` / `Dataset.slice()` return Int16Array/Float32Array buffers of the correct shape and dtype that contain incorrect bytes. Downstream tools (NWB readers, viewers, scientific pipelines) cannot detect this.

## Minimal reproducer

```sh
mkdir h5wasm-repro && cd $_
cat > package.json <<'PJ'
{
  "name": "h5wasm-repro", "type": "module",
  "dependencies": { "h5wasm": "0.10.2", "h5wasm-plugins": "0.3.0" }
}
PJ
npm install
python3 -c "
import h5py, hdf5plugin, numpy as np
data = np.random.default_rng(42).integers(-32768, 32767, (1000, 4), dtype='<i2')
with h5py.File('tiny.h5', 'w') as f:
    f.create_dataset('gzip_ref',     data=data, compression='gzip')
    f.create_dataset('blosc2_buggy', data=data, **hdf5plugin.Blosc2())
"
node -e "
import('h5wasm').then(async h5wasm => {
  const { install_local_plugins } = await import('h5wasm-plugins');
  await h5wasm.ready;
  install_local_plugins(h5wasm.Module);
  const fs = await import('node:fs');
  h5wasm.Module.FS.writeFile('/tiny.h5', new Uint8Array(fs.readFileSync('tiny.h5')));
  const f = new h5wasm.File('/tiny.h5', 'r');
  const a = f.get('gzip_ref').slice([[0,4],[0,4]]);
  const b = f.get('blosc2_buggy').slice([[0,4],[0,4]]);
  console.log('gzip   first 8:', Array.from(a));
  console.log('blosc2 first 8:', Array.from(b));
  console.log('IDENTICAL?', JSON.stringify(Array.from(a)) === JSON.stringify(Array.from(b)));
  f.close();
});
"
```

Expected: `IDENTICAL? true` (both decompress to the same source bytes).
Actual: `IDENTICAL? false` — blosc2 returns garbage.

With this PR's `-DH5WASM_ALLOW_DYNAMIC_EXECUTION=ON` build, the assertion passes.

## Why an option rather than flipping the default

PR #106 set `DYNAMIC_EXECUTION=0` specifically to support strict-CSP deployments where `unsafe-eval` isn't permitted. Flipping the default back would regress those users. An opt-in CMake flag lets consumers who need codec support build their own `.wasm` while leaving the published default untouched.

If you'd prefer a different approach — e.g. ship two build variants (`hdf5_util.js` strict + `hdf5_util_full.js` permissive), or document the trade-off in README without a build option — happy to amend.

## Adjacent improvements (separate PR if of interest)

While debugging this, I also found two complementary fixes useful for biom's downstream codec layer:
1. Export `H5Zregister`/`H5Zunregister`/`H5Zfilter_avail` from `EXPORTED_FUNCTIONS` — lets callers register pure-JS filter callbacks as a fallback for strict-CSP environments where even `DYNAMIC_EXECUTION=1` isn't an option.
2. Add `addFunction`/`removeFunction`/`getValue`/`setValue`/`HEAPU32`/`HEAP32`/`HEAPF64` to `EXPORTED_RUNTIME_METHODS` — required to wire JS function pointers across the WASM boundary.

These aren't strictly needed for the dlopen fix; happy to split into a follow-up PR if you'd like to land this one first.

## Context

Found while building [biom-h5](https://github.com/biom-labs/biom/tree/feat/biom-h5-codecs/packages/biom-h5) — a client-side NWB reader for our scientific platform. We've been vendoring this exact patch for the past few days; verified byte-for-byte correctness across all 10 h5wasm-plugins codecs (blosc2/zstd/bitshuffle/lz4/bz2/jpeg/zfp/bitround/bitgroom/blosc) against in-process h5py baselines. Happy to wire whatever test scaffolding you'd like added.

Thanks for h5wasm — it's a huge win for HDF5 in the browser.